### PR TITLE
Adds no op workflow that always passes

### DIFF
--- a/.github/workflows/no-op.yml
+++ b/.github/workflows/no-op.yml
@@ -1,0 +1,20 @@
+# No Op workflow that will always pass. This is so that we can force branches to be up
+# to date with master before getting merged. For some reason, GitHub requires an action
+# to enable this setting.
+# TODO: Remove this workflow when we have a more suitable action to run on pull_request
+#       and update the settings in GutHub.
+
+name: No Op
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  no-op:
+    name: No Op
+    runs-on: ubuntu-latest
+    steps:
+      - name: Always Pass
+        run: exit 0


### PR DESCRIPTION
I've added the setting so that branches can only be merged to master if this stage passes and if they're up to date with master. Branches with open PRs will have to merge in master and push again for the action to run. Then they should be able to be merged (provided they're up to date with master).

I've set this to just run on pull requests targeting master, so that it won't unnecessarily run on PRs into feature branches.