### PR TITLE
Pipes damage dealt through effects

### DIFF
--- a/Danki2/Assets/Scripts/Actor/Actor.cs
+++ b/Danki2/Assets/Scripts/Actor/Actor.cs
@@ -68,21 +68,13 @@ public abstract class Actor : MonoBehaviour
         
     public bool Opposes(Actor target)
     {
-        return tag != target.tag;
+        return !CompareTag(target.tag);
     }
 
     public void DamageTarget(Actor target, int damage)
     {
         if (target.Dead) return;
-
-        if (damage < 0)
-        {
-            Debug.LogWarning("Tried to deal negative damage to target.");
-            return;
-        }
-
-        // TODO: Put damage through an offensive pipeline
-        target.HealthManager.ReceiveDamage(damage);
+        target.HealthManager.ReceiveDamage(EffectManager.ProcessDamage(damage));
     }
 
     public void InterruptableAction(float delay, InterruptionType interruptionType, Action action)

--- a/Danki2/Assets/Scripts/Actor/Services/HealthManager.cs
+++ b/Danki2/Assets/Scripts/Actor/Services/HealthManager.cs
@@ -27,14 +27,22 @@ public class HealthManager
 
     public void TickDamage(int damage)
     {
-        if (damage < 0) return;
+        if (damage < 0)
+        {
+            Debug.LogWarning($"Tried to tick negative damage, value: {damage}");
+            return;
+        }
 
         ModifyHealth(-damage);
     }
 
     public void ReceiveDamage(int damage)
     {
-        if (damage < 0) return;
+        if (damage < 0)
+        {
+            Debug.LogWarning($"Tried to receive negative damage, value: {damage}");
+            return;
+        }
 
         // TODO: Pass this damage through a defensive pipeline.
         ModifyHealth(-damage);

--- a/Danki2/Assets/Scripts/Effects/Effect.cs
+++ b/Danki2/Assets/Scripts/Effects/Effect.cs
@@ -19,4 +19,9 @@
     {
         return value;
     }
+
+    public virtual int ProcessDamage(int damage)
+    {
+        return damage;
+    }
 }

--- a/Danki2/Assets/Scripts/Effects/EffectManager.cs
+++ b/Danki2/Assets/Scripts/Effects/EffectManager.cs
@@ -71,11 +71,14 @@ public class EffectManager : StatPipe
 
     public float ProcessStat(Stat stat, float value)
     {
-        float processedValue = value;
+        ForEachEffect(e => value = e.ProcessStat(stat, value));
+        return value;
+    }
 
-        ForEachEffect(e => processedValue = e.ProcessStat(stat, processedValue));
-
-        return processedValue;
+    public int ProcessDamage(int damage)
+    {
+        ForEachEffect(e => damage = e.ProcessDamage(damage));
+        return damage;
     }
 
     private void TickActiveEffects()


### PR DESCRIPTION
To test it out I created the following effect:
```c#
public class DoubleDamage : Effect
{
    public override int ProcessDamage(int damage)
    {
        return damage * 2;
    }
}
```
Then added the following code to the update method on the player:
```c#
if (Input.GetKeyDown(KeyCode.F))
{
    EffectManager.AddPassiveEffect(new DoubleDamage());
}
```
Then each time you press "F", outgoing damage will be doubled.