### PR TITLE
Increases wolf attack speed

### DIFF
--- a/Danki2/Assets/Prefabs/Enemies/Wolf.prefab
+++ b/Danki2/Assets/Prefabs/Enemies/Wolf.prefab
@@ -315,8 +315,8 @@ MonoBehaviour:
   navmeshAgent: {fileID: -7685572653157387656}
   _biteCastTime: 0.5
   _pounceCastTime: 0.5
-  _biteTotalCooldown: 5
-  _pounceTotalCooldown: 8
+  _biteTotalCooldown: 2.5
+  _pounceTotalCooldown: 5
   agroTime: 3
   howl: {fileID: -3268726625634297962}
 --- !u!114 &3467548966888005537
@@ -973,6 +973,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8063099716140605082}
     m_Modifications:
+    - target: {fileID: 1979858862639965533, guid: 1c1ef6601784e49429e64e8545ef1c4a,
+        type: 3}
+      propertyPath: m_Name
+      value: FloatingDamageText
+      objectReference: {fileID: 0}
     - target: {fileID: 1979858862639965505, guid: 1c1ef6601784e49429e64e8545ef1c4a,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1077,11 +1082,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1979858862639965533, guid: 1c1ef6601784e49429e64e8545ef1c4a,
-        type: 3}
-      propertyPath: m_Name
-      value: FloatingDamageText
       objectReference: {fileID: 0}
     - target: {fileID: 3486282139536815869, guid: 1c1ef6601784e49429e64e8545ef1c4a,
         type: 3}

--- a/Danki2/Assets/Scripts/AI/Behaviour/Behaviours/Attack/WolfAttack.cs
+++ b/Danki2/Assets/Scripts/AI/Behaviour/Behaviours/Attack/WolfAttack.cs
@@ -39,7 +39,6 @@ public class WolfAttack : Behaviour
         )
         {
             wolf.Pounce();
-            return;
         }
 
     }


### PR DESCRIPTION
Ended up bringing these down further than I thought we would, but I think it makes the wolf feel a lot more aggressive, like you're always on the back foot looking for an attack. See what you think, maybe 3s would be more reasonable?

I don't think the pounce cooldown makes much difference as it's always off by the time the wolf would realistically use it again. Lowered anyway so that it could pounce earlier if the player runs away.