### PR TITLE
Player settings idea

### DIFF
--- a/Danki2/Assets/Scripts/Actor/Player/AbilityManager.cs
+++ b/Danki2/Assets/Scripts/Actor/Player/AbilityManager.cs
@@ -19,11 +19,11 @@ public class AbilityManager
     public CastingStatus CastingStatus { get; private set; } = CastingStatus.Ready;
     public Subject<Tuple<bool, Direction>> AbilityCompletionSubject { get; } = new Subject<Tuple<bool, Direction>>();
 
-    public AbilityManager(Player player, float abilityTimeoutLimit, float abilityCooldown, Subject updateSubject, Subject lateUpdateSubject)
+    public AbilityManager(Player player, Subject updateSubject, Subject lateUpdateSubject)
 	{
 		this.player = player;
-        this.abilityTimeoutLimit = abilityTimeoutLimit;
-        this.abilityCooldown = abilityCooldown;
+        this.abilityTimeoutLimit = player.Settings.ComboTimeout;
+        this.abilityCooldown = player.Settings.CooldownDuringCombo;
 
         updateSubject.Subscribe(TickAbilityCooldown);
         lateUpdateSubject.Subscribe(HandleAbilities);

--- a/Danki2/Assets/Scripts/Actor/Player/Editor/PlayerEditor.cs
+++ b/Danki2/Assets/Scripts/Actor/Player/Editor/PlayerEditor.cs
@@ -12,16 +12,28 @@ public class PlayerEditor : ActorEditor
 
         EditorGUILayout.LabelField("Abilities", EditorStyles.boldLabel);
         EditorGUI.indentLevel++;
-            player.abilityCooldown = EditorGUILayout.Slider("Cooldown", player.abilityCooldown, 0, 2);
-            player.abilityTimeoutLimit = EditorGUILayout.Slider("Timeout", player.abilityTimeoutLimit, 2, 10);
+            var cooldownDuringCombo = EditorGUILayout.Slider("CD during combo", player.Settings.CooldownDuringCombo, 0, 2);
+            var cooldownAfterCombo = EditorGUILayout.Slider("CD after combo", player.Settings.CooldownAfterCombo, 0, 2);
+            var comboTimeout = EditorGUILayout.Slider("Combo timeout", player.Settings.ComboTimeout, 2, 10);
+            var rollResetsCombo = EditorGUILayout.Toggle("Roll resets combo", player.Settings.RollResetsCombo);
         EditorGUI.indentLevel--;
 
         EditorGUILayout.LabelField("Roll", EditorStyles.boldLabel);
         EditorGUI.indentLevel++;
-            player.totalRollCooldown = EditorGUILayout.Slider("Cooldown", player.totalRollCooldown, 0, 5);
-            player.rollDuration = EditorGUILayout.Slider("Duration", player.rollDuration, 0, 1);
-            player.rollSpeedMultiplier = EditorGUILayout.Slider("Speed Multiplier", player.rollSpeedMultiplier, 1, 10);
+            var totalRollCooldown = EditorGUILayout.Slider("Cooldown", player.Settings.TotalRollCooldown, 0, 5);
+            var rollDuration = EditorGUILayout.Slider("Duration", player.Settings.RollDuration, 0, 1);
+            var rollSpeedMultiplier = EditorGUILayout.Slider("Speed Multiplier", player.Settings.RollSpeedMultiplier, 1, 10);
         EditorGUI.indentLevel--;
+
+        player.Settings = new PlayerSettings(
+            cooldownDuringCombo,
+            cooldownAfterCombo,
+            comboTimeout,
+            rollResetsCombo,
+            totalRollCooldown,
+            rollDuration,
+            rollSpeedMultiplier
+        );
 
         if (GUI.changed)
         {

--- a/Danki2/Assets/Scripts/Actor/Player/Player.cs
+++ b/Danki2/Assets/Scripts/Actor/Player/Player.cs
@@ -4,17 +4,9 @@ public class Player : Actor
 {
     public override ActorType Type => ActorType.Player;
 
-    // Settings
-    [HideInInspector]
-    public float abilityCooldown = 1f;
-    [HideInInspector]
-    public float totalRollCooldown = 1f;
-    [HideInInspector]
-    public float rollDuration = 0.2f;
-    [HideInInspector]
-    public float rollSpeedMultiplier = 3f;
-    [HideInInspector]
-    public float abilityTimeoutLimit = 5f;
+    // This is no readonly as the editor needs to updates it. Seems safer than risking individual settings being updated.
+    public PlayerSettings Settings { get; set; } = new PlayerSettings();
+
     private float remainingRollCooldown = 0f;
 
     // Components
@@ -45,7 +37,7 @@ public class Player : Actor
 
         RegisterAbilityDataDiffer(new AbilityDataOrbsDiffer(AbilityTree));
         SetAbilityBonusCalculator(new AbilityBonusOrbsCalculator(AbilityTree));
-        AbilityManager = new AbilityManager(this, abilityTimeoutLimit, abilityCooldown, updateSubject, lateUpdateSubject);
+        AbilityManager = new AbilityManager(this, updateSubject, lateUpdateSubject);
         TargetFinder = new PlayerTargetFinder(this, updateSubject);
     }
 
@@ -69,18 +61,18 @@ public class Player : Actor
 
         bool rolled = MovementManager.TryLockMovement(
             MovementLockType.Dash,
-            rollDuration,
-            GetStat(Stat.Speed) * rollSpeedMultiplier,
+            Settings.RollDuration,
+            GetStat(Stat.Speed) * Settings.RollSpeedMultiplier,
             direction,
             direction
         );
 
         if (rolled)
         {
-            remainingRollCooldown = totalRollCooldown;
+            remainingRollCooldown = Settings.TotalRollCooldown;
             rollAudio.Play();
             RollSubject.Next();
-            StartTrail(rollDuration * 2);
+            StartTrail(Settings.RollDuration * 2);
         }
     }
 

--- a/Danki2/Assets/Scripts/Actor/Player/PlayerSettings.cs
+++ b/Danki2/Assets/Scripts/Actor/Player/PlayerSettings.cs
@@ -1,0 +1,32 @@
+﻿public class PlayerSettings
+{
+    public PlayerSettings() { }
+
+    public PlayerSettings(
+        float cooldownDuringCombo,
+        float cooldownAfterCombo,
+        float comboTimeout,
+        bool rollResetsCombo,
+        float totalRollCooldown,
+        float rollDuration,
+        float rollSpeedMultiplier
+    )
+    {
+        this.CooldownDuringCombo = cooldownDuringCombo;
+        this.CooldownAfterCombo = cooldownAfterCombo;
+        this.ComboTimeout = comboTimeout;
+        this.RollResetsCombo = rollResetsCombo;
+        this.TotalRollCooldown = totalRollCooldown;
+        this.RollDuration = rollDuration;
+        this.RollSpeedMultiplier = rollSpeedMultiplier;
+    }
+
+    public float CooldownDuringCombo { get; } = 0.5f;
+    public float CooldownAfterCombo { get; } = 2.5f;
+    public float ComboTimeout { get; } = 2.5f;
+    public bool RollResetsCombo { get; } = true;
+
+    public float TotalRollCooldown { get; } = 1f;
+    public float RollDuration { get; } = 0.2f;
+    public float RollSpeedMultiplier { get; } = 3f;
+}

--- a/Danki2/Assets/Scripts/Actor/Player/PlayerSettings.cs.meta
+++ b/Danki2/Assets/Scripts/Actor/Player/PlayerSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 878ef9f27e659db458b528ae825350aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Danki2/Assets/Scripts/UI/Static/TreeDepth.cs
+++ b/Danki2/Assets/Scripts/UI/Static/TreeDepth.cs
@@ -22,7 +22,7 @@ public class TreeDepth : MonoBehaviour
     private void Start()
     {
         this.player = RoomManager.Instance.Player;
-        this.abilityTimeOutLimit = this.player.abilityTimeoutLimit;
+        this.abilityTimeOutLimit = this.player.Settings.ComboTimeout;
 
         this.player.AbilityTree.CurrentDepthSubject.Subscribe(newDepth =>
         {


### PR DESCRIPTION
With the changes to the ability manager, we're up to 7 editor fields on the Player.

Changing to a Settings class allows us to tidy these into a single property, which blocks modification of individual settings while still allowing the editor to update them.

It will be easy to use this pattern in other places too.