### PR TITLE
Bind channel times into tooltips

### DIFF
--- a/Danki2/Assets/Prefabs/Meta/AbilityLookup.prefab
+++ b/Danki2/Assets/Prefabs/Meta/AbilityLookup.prefab
@@ -87,6 +87,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       finisher: 0
+      channelDuration: 0
     - displayName: Whirlwind
       tooltip: Channel (2s) - Deal {PRIMARY_DAMAGE} damage up to 6 times while channeling
         and an additional {SECONDARY_DAMAGE} damage if the channel completes to all
@@ -108,6 +109,7 @@ MonoBehaviour:
           tooltip: No longer slowed whilst channeling.
           requiredOrbs: 02000000
       finisher: 0
+      channelDuration: 2
     - displayName: Fireball
       tooltip: Instant Cast - Deal {PRIMARY_DAMAGE} damage on impact.
       baseAbilityData:
@@ -123,6 +125,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       finisher: 0
+      channelDuration: 0
     - displayName: Poison Dagger
       tooltip: Instant Cast - Throw a dagger which deals {PRIMARY_DAMAGE} damage on
         impact and poisons the enemy for {SECONDARY_DAMAGE} damage over 5 seconds.
@@ -139,6 +142,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       finisher: 0
+      channelDuration: 0
     - displayName: Bite
       tooltip: Instant Cast - Deal {PRIMARY_DAMAGE} damage.
       baseAbilityData:
@@ -154,6 +158,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       finisher: 0
+      channelDuration: 0
     - displayName: Pounce
       tooltip: Instant Cast - Deal {PRIMARY_DAMAGE} damage.
       baseAbilityData:
@@ -169,6 +174,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       finisher: 0
+      channelDuration: 0
     - displayName: Dash
       tooltip: Instant Cast - Dash a short distance in the direction of casting.
       baseAbilityData:
@@ -184,6 +190,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       finisher: 0
+      channelDuration: 0
     - displayName: Lunge
       tooltip: Instant Cast - Lunge up to 5m and deal {PRIMARY_DAMAGE} damage to enemies
         in a small cone.
@@ -200,6 +207,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       finisher: 0
+      channelDuration: 0
     - displayName: Smash
       tooltip: Instant Cast - Deal {PRIMARY_DAMAGE} damage in a small circle.
       baseAbilityData:
@@ -219,6 +227,7 @@ MonoBehaviour:
           tooltip: Stun all affected enemies for 3 seconds.
           requiredOrbs: 0100000001000000
       finisher: 1
+      channelDuration: 0
     - displayName: Sprint
       tooltip: Cast (1s) - Increase speed by 3 for 5 seconds.
       baseAbilityData:
@@ -234,6 +243,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       finisher: 0
+      channelDuration: 1
     - displayName: Leap
       tooltip: Instant Cast - Leap to a target location.
       baseAbilityData:
@@ -253,6 +263,7 @@ MonoBehaviour:
           tooltip: On impact, stun surrounding enemies for 3 seconds.
           requiredOrbs: 0000000000000000
       finisher: 0
+      channelDuration: 0
     - displayName: Leeching Strike
       tooltip: Instant Cast - Deal {PRIMARY_DAMAGE} damage in a cone and heal for
         {HEAL} + 1 per enemy hit.
@@ -269,6 +280,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       finisher: 0
+      channelDuration: 0
     - displayName: Meditate
       tooltip: Charge (5s) - Increase power by 1 for every second charged. Lasts 10
         seconds.
@@ -293,6 +305,7 @@ MonoBehaviour:
           tooltip: Increase power by 2 for every second charged instead.
           requiredOrbs: 000000000000000000000000
       finisher: 1
+      channelDuration: 5
     - displayName: Bash
       tooltip: Instant Cast - Deal {PRIMARY_DAMAGE} to enemies in a cone, stuns for
         1 second.
@@ -309,6 +322,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       finisher: 0
+      channelDuration: 0
     - displayName: Sweeping Strike
       tooltip: Instant Cast - Deal {PRIMARY_DAMAGE} damage to enemies in a cone and
         knockback all enemies hit.
@@ -325,6 +339,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       finisher: 0
+      channelDuration: 0
     - displayName: Hook
       tooltip: Instant Cast - Throw a hook at an enemy and pull them towards the player.
         The hook is coated in a serum which causes the target to be stunned for 2
@@ -342,6 +357,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       finisher: 0
+      channelDuration: 0
     - displayName: Backstab
       tooltip: Instant Cast - With an unexpected stab from behind, deal {PRIMARY_DAMAGE}
         to a target. However if the opponent is facing you the stab will fail!
@@ -358,6 +374,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       finisher: 0
+      channelDuration: 0
     - displayName: Piercing Rush
       tooltip: Cast (2s) - Dash for up to 10m dealing {PRIMARY_DAMAGE} damage to all
         enemies you pass.
@@ -383,6 +400,7 @@ MonoBehaviour:
             damage to enemies in a cone behind you.
           requiredOrbs: 020000000100000001000000
       finisher: 1
+      channelDuration: 2
     - displayName: Parry
       tooltip: Instant Cast - Absorb each attack for 1 second and return 50% of the
         damage back to attackers.
@@ -399,6 +417,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       finisher: 0
+      channelDuration: 0
     - displayName: Intimidating Shout
       tooltip: Instant Cast - Reduce defence of surrounding enemies by 2 for 6 seconds.
       baseAbilityData:
@@ -414,6 +433,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       finisher: 0
+      channelDuration: 0
     - displayName: Rend
       tooltip: Charge (3s) - Applies a 5 second DOT for {PRIMARY_DAMAGE} damage, multiplied
         by the time charged, to all surrounding enemies.
@@ -430,6 +450,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       finisher: 0
+      channelDuration: 3
     - displayName: Bandage
       tooltip: Channel (5s) - Gain {HEAL} health per second. Rooted while channeling.
       baseAbilityData:
@@ -449,6 +470,7 @@ MonoBehaviour:
           tooltip: Slowed by 50% rather than rooted while channeling.
           requiredOrbs: 0000000001000000
       finisher: 1
+      channelDuration: 5
     - displayName: Disengage
       tooltip: Instant Cast - Leap backwards.
       baseAbilityData:
@@ -468,6 +490,7 @@ MonoBehaviour:
           tooltip: Deal {PRIMARY_DAMAGE} damage to enemies nearby before leaping.
           requiredOrbs: 0100000001000000
       finisher: 0
+      channelDuration: 0
     - displayName: Sword Throw
       tooltip: Cast (2s) - Throw a sword which deals {PRIMARY_DAMAGE} damage on impact.
       baseAbilityData:
@@ -488,6 +511,7 @@ MonoBehaviour:
             over 5 seconds.
           requiredOrbs: 0200000002000000
       finisher: 1
+      channelDuration: 2
     - displayName: Fan of Knives
       tooltip: Instant Cast - Throw a fan of 3 knives in an arc, which deal {PRIMARY_DAMAGE}
         damage on impact.
@@ -508,6 +532,7 @@ MonoBehaviour:
           tooltip: Throw an additional 2 knives.
           requiredOrbs: 020000000000000001000000
       finisher: 0
+      channelDuration: 0
     - displayName: Hamstring
       tooltip: Instant Cast - Deal {PRIMARY_DAMAGE} damage to the target and decrease
         their defence by 2 for 10 seconds.
@@ -528,3 +553,4 @@ MonoBehaviour:
           tooltip: Increase damage dealt by 4.
           requiredOrbs: 00000000
       finisher: 0
+      channelDuration: 0

--- a/Danki2/Assets/Prefabs/Meta/AbilityLookup.prefab
+++ b/Danki2/Assets/Prefabs/Meta/AbilityLookup.prefab
@@ -73,7 +73,7 @@ MonoBehaviour:
     - Hamstring
     _values:
     - displayName: Slash
-      tooltip: Instant Cast - Deal {PRIMARY_DAMAGE} damage to enemies in a cone.
+      tooltip: Deal {PRIMARY_DAMAGE} damage to enemies in a cone.
       baseAbilityData:
         primaryDamage: 5
         secondaryDamage: 0
@@ -89,9 +89,9 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 0
     - displayName: Whirlwind
-      tooltip: Channel (2s) - Deal {PRIMARY_DAMAGE} damage up to 6 times while channeling
-        and an additional {SECONDARY_DAMAGE} damage if the channel completes to all
-        nearby enemies. Slowed by 50% during channel.
+      tooltip: Deal {PRIMARY_DAMAGE} damage up to 6 times while channeling and an
+        additional {SECONDARY_DAMAGE} damage if the channel completes to all nearby
+        enemies. Slowed by 50% during channel.
       baseAbilityData:
         primaryDamage: 1
         secondaryDamage: 3
@@ -111,7 +111,7 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 2
     - displayName: Fireball
-      tooltip: Instant Cast - Deal {PRIMARY_DAMAGE} damage on impact.
+      tooltip: Deal {PRIMARY_DAMAGE} damage on impact.
       baseAbilityData:
         primaryDamage: 5
         secondaryDamage: 0
@@ -127,8 +127,8 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 0
     - displayName: Poison Dagger
-      tooltip: Instant Cast - Throw a dagger which deals {PRIMARY_DAMAGE} damage on
-        impact and poisons the enemy for {SECONDARY_DAMAGE} damage over 5 seconds.
+      tooltip: Throw a dagger which deals {PRIMARY_DAMAGE} damage on impact and poisons
+        the enemy for {SECONDARY_DAMAGE} damage over 5 seconds.
       baseAbilityData:
         primaryDamage: 2
         secondaryDamage: 7
@@ -144,7 +144,7 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 0
     - displayName: Bite
-      tooltip: Instant Cast - Deal {PRIMARY_DAMAGE} damage.
+      tooltip: Deal {PRIMARY_DAMAGE} damage.
       baseAbilityData:
         primaryDamage: 5
         secondaryDamage: 0
@@ -160,7 +160,7 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 0
     - displayName: Pounce
-      tooltip: Instant Cast - Deal {PRIMARY_DAMAGE} damage.
+      tooltip: Deal {PRIMARY_DAMAGE} damage.
       baseAbilityData:
         primaryDamage: 4
         secondaryDamage: 0
@@ -176,7 +176,7 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 0
     - displayName: Dash
-      tooltip: Instant Cast - Dash a short distance in the direction of casting.
+      tooltip: Dash a short distance in the direction of casting.
       baseAbilityData:
         primaryDamage: 0
         secondaryDamage: 0
@@ -192,8 +192,8 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 0
     - displayName: Lunge
-      tooltip: Instant Cast - Lunge up to 5m and deal {PRIMARY_DAMAGE} damage to enemies
-        in a small cone.
+      tooltip: Lunge up to 5m and deal {PRIMARY_DAMAGE} damage to enemies in a small
+        cone.
       baseAbilityData:
         primaryDamage: 3
         secondaryDamage: 0
@@ -209,7 +209,7 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 0
     - displayName: Smash
-      tooltip: Instant Cast - Deal {PRIMARY_DAMAGE} damage in a small circle.
+      tooltip: Deal {PRIMARY_DAMAGE} damage in a small circle.
       baseAbilityData:
         primaryDamage: 10
         secondaryDamage: 0
@@ -229,7 +229,7 @@ MonoBehaviour:
       finisher: 1
       channelDuration: 0
     - displayName: Sprint
-      tooltip: Cast (1s) - Increase speed by 3 for 5 seconds.
+      tooltip: Increase speed by 3 for 5 seconds.
       baseAbilityData:
         primaryDamage: 0
         secondaryDamage: 0
@@ -245,7 +245,7 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 1
     - displayName: Leap
-      tooltip: Instant Cast - Leap to a target location.
+      tooltip: Leap to a target location.
       baseAbilityData:
         primaryDamage: 0
         secondaryDamage: 0
@@ -265,8 +265,8 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 0
     - displayName: Leeching Strike
-      tooltip: Instant Cast - Deal {PRIMARY_DAMAGE} damage in a cone and heal for
-        {HEAL} + 1 per enemy hit.
+      tooltip: Deal {PRIMARY_DAMAGE} damage in a cone and heal for {HEAL} + 1 per
+        enemy hit.
       baseAbilityData:
         primaryDamage: 2
         secondaryDamage: 0
@@ -282,8 +282,7 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 0
     - displayName: Meditate
-      tooltip: Charge (5s) - Increase power by 1 for every second charged. Lasts 10
-        seconds.
+      tooltip: Increase power by 1 for every second charged. Lasts 10 seconds.
       baseAbilityData:
         primaryDamage: 0
         secondaryDamage: 0
@@ -307,8 +306,7 @@ MonoBehaviour:
       finisher: 1
       channelDuration: 5
     - displayName: Bash
-      tooltip: Instant Cast - Deal {PRIMARY_DAMAGE} to enemies in a cone, stuns for
-        1 second.
+      tooltip: Deal {PRIMARY_DAMAGE} to enemies in a cone, stuns for 1 second.
       baseAbilityData:
         primaryDamage: 3
         secondaryDamage: 0
@@ -324,8 +322,8 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 0
     - displayName: Sweeping Strike
-      tooltip: Instant Cast - Deal {PRIMARY_DAMAGE} damage to enemies in a cone and
-        knockback all enemies hit.
+      tooltip: Deal {PRIMARY_DAMAGE} damage to enemies in a cone and knockback all
+        enemies hit.
       baseAbilityData:
         primaryDamage: 5
         secondaryDamage: 0
@@ -341,9 +339,8 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 0
     - displayName: Hook
-      tooltip: Instant Cast - Throw a hook at an enemy and pull them towards the player.
-        The hook is coated in a serum which causes the target to be stunned for 2
-        seconds.
+      tooltip: Throw a hook at an enemy and pull them towards the player. The hook
+        is coated in a serum which causes the target to be stunned for 2 seconds.
       baseAbilityData:
         primaryDamage: 0
         secondaryDamage: 0
@@ -359,8 +356,8 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 0
     - displayName: Backstab
-      tooltip: Instant Cast - With an unexpected stab from behind, deal {PRIMARY_DAMAGE}
-        to a target. However if the opponent is facing you the stab will fail!
+      tooltip: With an unexpected stab from behind, deal {PRIMARY_DAMAGE} to a target.
+        However if the opponent is facing you the stab will fail!
       baseAbilityData:
         primaryDamage: 16
         secondaryDamage: 0
@@ -376,8 +373,8 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 0
     - displayName: Piercing Rush
-      tooltip: Cast (2s) - Dash for up to 10m dealing {PRIMARY_DAMAGE} damage to all
-        enemies you pass.
+      tooltip: Dash for up to 10m dealing {PRIMARY_DAMAGE} damage to all enemies you
+        pass.
       baseAbilityData:
         primaryDamage: 8
         secondaryDamage: 0
@@ -402,8 +399,8 @@ MonoBehaviour:
       finisher: 1
       channelDuration: 2
     - displayName: Parry
-      tooltip: Instant Cast - Absorb each attack for 1 second and return 50% of the
-        damage back to attackers.
+      tooltip: Absorb each attack for 1 second and return 50% of the damage back to
+        attackers.
       baseAbilityData:
         primaryDamage: 0
         secondaryDamage: 0
@@ -419,7 +416,7 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 0
     - displayName: Intimidating Shout
-      tooltip: Instant Cast - Reduce defence of surrounding enemies by 2 for 6 seconds.
+      tooltip: Reduce defence of surrounding enemies by 2 for 6 seconds.
       baseAbilityData:
         primaryDamage: 0
         secondaryDamage: 0
@@ -435,8 +432,8 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 0
     - displayName: Rend
-      tooltip: Charge (3s) - Applies a 5 second DOT for {PRIMARY_DAMAGE} damage, multiplied
-        by the time charged, to all surrounding enemies.
+      tooltip: Applies a 5 second DOT for {PRIMARY_DAMAGE} damage, multiplied by the
+        time charged, to all surrounding enemies.
       baseAbilityData:
         primaryDamage: 5
         secondaryDamage: 0
@@ -452,7 +449,7 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 3
     - displayName: Bandage
-      tooltip: Channel (5s) - Gain {HEAL} health per second. Rooted while channeling.
+      tooltip: Gain {HEAL} health per second. Rooted while channeling.
       baseAbilityData:
         primaryDamage: 0
         secondaryDamage: 0
@@ -472,7 +469,7 @@ MonoBehaviour:
       finisher: 1
       channelDuration: 5
     - displayName: Disengage
-      tooltip: Instant Cast - Leap backwards.
+      tooltip: Leap backwards.
       baseAbilityData:
         primaryDamage: 4
         secondaryDamage: 0
@@ -492,7 +489,7 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 0
     - displayName: Sword Throw
-      tooltip: Cast (2s) - Throw a sword which deals {PRIMARY_DAMAGE} damage on impact.
+      tooltip: Throw a sword which deals {PRIMARY_DAMAGE} damage on impact.
       baseAbilityData:
         primaryDamage: 12
         secondaryDamage: 6
@@ -513,8 +510,8 @@ MonoBehaviour:
       finisher: 1
       channelDuration: 2
     - displayName: Fan of Knives
-      tooltip: Instant Cast - Throw a fan of 3 knives in an arc, which deal {PRIMARY_DAMAGE}
-        damage on impact.
+      tooltip: Throw a fan of 3 knives in an arc, which deal {PRIMARY_DAMAGE} damage
+        on impact.
       baseAbilityData:
         primaryDamage: 2
         secondaryDamage: 0
@@ -534,8 +531,8 @@ MonoBehaviour:
       finisher: 0
       channelDuration: 0
     - displayName: Hamstring
-      tooltip: Instant Cast - Deal {PRIMARY_DAMAGE} damage to the target and decrease
-        their defence by 2 for 10 seconds.
+      tooltip: Deal {PRIMARY_DAMAGE} damage to the target and decrease their defence
+        by 2 for 10 seconds.
       baseAbilityData:
         primaryDamage: 3
         secondaryDamage: 0

--- a/Danki2/Assets/Scripts/Abilities/Channel/Cast/Cast.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Cast/Cast.cs
@@ -3,12 +3,9 @@
 public abstract class Cast : Channel
 {
     public sealed override ChannelType ChannelType => ChannelType.Cast;
-    public sealed override float Duration => CastTime;
 
-    protected abstract float CastTime { get; }
-
-    protected Cast(Actor owner, AbilityData abilityData, string[] availableBonuses)
-        : base(owner, abilityData, availableBonuses)
+    protected Cast(Actor owner, AbilityData abilityData, string[] availableBonuses, float duration)
+        : base(owner, abilityData, availableBonuses, duration)
     {
     }
 

--- a/Danki2/Assets/Scripts/Abilities/Channel/Cast/PiercingRush.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Cast/PiercingRush.cs
@@ -3,8 +3,6 @@
 [Ability(AbilityReference.PiercingRush, new[] { "Daze", "Jetstream" })]
 public class PiercingRush : Cast
 {
-    protected override float CastTime => 2f;
-
     private const float minimumCastRange = 2f;
     private const float maximumCastRange = 10f;
     private const float dashDamageWidth = 6f;
@@ -24,7 +22,8 @@ public class PiercingRush : Cast
 
     public override ChannelEffectOnMovement EffectOnMovement => ChannelEffectOnMovement.Root;
 
-    public PiercingRush(Actor owner, AbilityData abilityData, string[] availableBonuses) : base(owner, abilityData, availableBonuses)
+    public PiercingRush(Actor owner, AbilityData abilityData, string[] availableBonuses, float duration)
+        : base(owner, abilityData, availableBonuses, duration)
     {
     }
 

--- a/Danki2/Assets/Scripts/Abilities/Channel/Cast/Sprint.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Cast/Sprint.cs
@@ -3,16 +3,14 @@
 [Ability(AbilityReference.Sprint)]
 public class Sprint : Cast
 {
-    protected override float CastTime => 1;
-
     private const int SpeedModification = 3;
     private const float SprintDuration = 5;
     
     private readonly Subject onCastCancelled = new Subject();
     private readonly Subject onCastEnd = new Subject();
 
-    public Sprint(Actor owner, AbilityData abilityData, string[] availableBonuses)
-        : base(owner, abilityData, availableBonuses)
+    public Sprint(Actor owner, AbilityData abilityData, string[] availableBonuses, float duration)
+        : base(owner, abilityData, availableBonuses, duration)
     {
     }
 

--- a/Danki2/Assets/Scripts/Abilities/Channel/Cast/SwordThrow.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Cast/SwordThrow.cs
@@ -3,14 +3,13 @@
 [Ability(AbilityReference.SwordThrow, new[] { "Poison Sword" })]
 public class SwordThrow : Cast
 {
-    protected override float CastTime => 2f;
-
     private const float swordSpeed = 10f;
     private const float poisonSwordDOTLength = 5f;
 
     public override ChannelEffectOnMovement EffectOnMovement => ChannelEffectOnMovement.Root;
 
-    public SwordThrow(Actor owner, AbilityData abilityData, string[] availableBonuses) : base(owner, abilityData, availableBonuses)
+    public SwordThrow(Actor owner, AbilityData abilityData, string[] availableBonuses, float duration)
+        : base(owner, abilityData, availableBonuses, duration)
     {
     }
 

--- a/Danki2/Assets/Scripts/Abilities/Channel/Channel.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Channel.cs
@@ -2,14 +2,16 @@
 
 public abstract class Channel : Ability
 {
-    public abstract float Duration { get; }
+    public float Duration { get; }
 
     public virtual ChannelType ChannelType => ChannelType.Channel;
 
     public virtual ChannelEffectOnMovement EffectOnMovement => ChannelEffectOnMovement.Stun;
 
-    protected Channel(Actor owner, AbilityData abilityData, string[] availableBonuses) : base(owner, abilityData, availableBonuses)
+    protected Channel(Actor owner, AbilityData abilityData, string[] availableBonuses, float duration)
+        : base(owner, abilityData, availableBonuses)
     {
+        Duration = duration;
     }
     
     public virtual void Start(Vector3 target) { }

--- a/Danki2/Assets/Scripts/Abilities/Channel/Channel/Bandage.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Channel/Bandage.cs
@@ -15,13 +15,12 @@ public class Bandage : Channel
 
     private Guid slowEffectId;
     
-    public override float Duration => 5f;
-    
     public override ChannelEffectOnMovement EffectOnMovement => HasBonus("Perseverance")
         ? ChannelEffectOnMovement.None
         : ChannelEffectOnMovement.Stun;
 
-    public Bandage(Actor owner, AbilityData abilityData, string[] availableBonuses) : base(owner, abilityData, availableBonuses)
+    public Bandage(Actor owner, AbilityData abilityData, string[] availableBonuses, float duration)
+        : base(owner, abilityData, availableBonuses, duration)
     {
     }
 

--- a/Danki2/Assets/Scripts/Abilities/Channel/Channel/Whirlwind.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Channel/Whirlwind.cs
@@ -18,11 +18,10 @@ public class Whirlwind : Channel
 
     private Repeater repeater;
 
-    public override float Duration => 2f;
-
     public override ChannelEffectOnMovement EffectOnMovement => ChannelEffectOnMovement.None;
 
-    public Whirlwind(Actor owner, AbilityData abilityData, string[] availableBonuses) : base(owner, abilityData, availableBonuses)
+    public Whirlwind(Actor owner, AbilityData abilityData, string[] availableBonuses, float duration)
+        : base(owner, abilityData, availableBonuses, duration)
     {
     }
 

--- a/Danki2/Assets/Scripts/Abilities/Channel/Charge/Charge.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Charge/Charge.cs
@@ -3,14 +3,11 @@
 public abstract class Charge : Channel
 {
     public sealed override ChannelType ChannelType => ChannelType.Charge;
-    public sealed override float Duration => ChargeTime;
-
-    protected abstract float ChargeTime { get; }
 
     protected float TimeCharged { get; private set; } = 0;
 
-    protected Charge(Actor owner, AbilityData abilityData, string[] availableBonuses)
-        : base(owner, abilityData, availableBonuses)
+    protected Charge(Actor owner, AbilityData abilityData, string[] availableBonuses, float duration)
+        : base(owner, abilityData, availableBonuses, duration)
     {
     }
 

--- a/Danki2/Assets/Scripts/Abilities/Channel/Charge/Meditate.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Charge/Meditate.cs
@@ -5,8 +5,6 @@ using UnityEngine;
 [Ability(AbilityReference.Meditate, new []{"Clarity", "GrowingRage"})]
 public class Meditate : Charge
 {
-    protected override float ChargeTime => 5;
-    
     private readonly Dictionary<Actor, Guid> slowedActors = new Dictionary<Actor, Guid>();
 
     private MeditateObject meditateObject;
@@ -15,13 +13,14 @@ public class Meditate : Charge
     private const int GrowingRageMultiplier = 2;
     private const float SlowMultiplier = 0.5f;
 
-    public Meditate(Actor owner, AbilityData abilityData, string[] availableBonuses) : base(owner, abilityData, availableBonuses)
+    public Meditate(Actor owner, AbilityData abilityData, string[] availableBonuses, float duration)
+        : base(owner, abilityData, availableBonuses, duration)
     {
     }
 
     protected override void Start()
     {
-        meditateObject = MeditateObject.Create(Owner.transform, ChargeTime);
+        meditateObject = MeditateObject.Create(Owner.transform, Duration);
         
         if (HasBonus("Clarity")) AddSlowEffects();
     }

--- a/Danki2/Assets/Scripts/Abilities/Channel/Charge/Rend.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Charge/Rend.cs
@@ -9,9 +9,8 @@ public class Rend : Charge
 
     private int cameraShakeCount = 0;
 
-    protected override float ChargeTime => 3f;
-
-    public Rend(Actor owner, AbilityData abilityData, string[] availableBonuses) : base(owner, abilityData, availableBonuses)
+    public Rend(Actor owner, AbilityData abilityData, string[] availableBonuses, float duration)
+        : base(owner, abilityData, availableBonuses, duration)
     {
     }
 
@@ -25,7 +24,7 @@ public class Rend : Charge
 
     public override void Cancel(Vector3 target) => End(TimeCharged);
 
-    public override void End(Vector3 target) => End(ChargeTime);
+    public override void End(Vector3 target) => End(Duration);
 
     private void End(float timeCharged)
     {

--- a/Danki2/Assets/Scripts/Abilities/Lookup/AbilityLookup.cs
+++ b/Danki2/Assets/Scripts/Abilities/Lookup/AbilityLookup.cs
@@ -17,6 +17,7 @@ public class AbilityLookup : Singleton<AbilityLookup>
     private readonly AbilityMap<List<TemplatedTooltipSegment>> templatedTooltipSegmentsMap = new AbilityMap<List<TemplatedTooltipSegment>>();
     private readonly AbilityMap<Dictionary<string, AbilityBonusData>> abilityBonusDataMap = new AbilityMap<Dictionary<string, AbilityBonusData>>();
     private readonly AbilityMap<bool> finisherLookup = new AbilityMap<bool>();
+    private readonly AbilityMap<float> channelDurationMap = new AbilityMap<float>();
 
     private readonly AbilityMap<Func<Actor, AbilityData, string[], InstantCast>> instantCastBuilderMap = new AbilityMap<Func<Actor, AbilityData, string[], InstantCast>>();
     private readonly AbilityMap<Func<Actor, AbilityData, string[], Channel>> channelBuilderMap = new AbilityMap<Func<Actor, AbilityData, string[], Channel>>();
@@ -114,6 +115,9 @@ public class AbilityLookup : Singleton<AbilityLookup>
 
     public bool IsFinisher(AbilityReference abilityReference) => finisherLookup[abilityReference];
 
+    public bool TryGetChannelDuration(AbilityReference abilityReference, out float channelDuration) =>
+        channelDurationMap.TryGetValue(abilityReference, out channelDuration);
+
     private void BuildMetadataLookups()
     {
         EnumUtils.ForEach<AbilityReference>(ability =>
@@ -127,6 +131,11 @@ public class AbilityLookup : Singleton<AbilityLookup>
             if (serializableAbilityMetadata.AbilityOrbType.HasValue)
             {
                 abilityOrbTypeMap[ability] = serializableAbilityMetadata.AbilityOrbType.Value;
+            }
+
+            if (abilityAttributeDataLookup[ability].Type.IsSubclassOf(typeof(Channel)))
+            {
+                channelDurationMap[ability] = serializableAbilityMetadata.ChannelDuration;
             }
 
             generatedOrbsMap[ability] = new OrbCollection(serializableAbilityMetadata.GeneratedOrbs);

--- a/Danki2/Assets/Scripts/Abilities/Lookup/Editor/AbilityLookupEditor.cs
+++ b/Danki2/Assets/Scripts/Abilities/Lookup/Editor/AbilityLookupEditor.cs
@@ -73,12 +73,28 @@ public class AbilityLookupEditor : Editor
         serializableAbilityMetadata.DisplayName = EditorGUILayout.TextField("Display Name", serializableAbilityMetadata.DisplayName);
         serializableAbilityMetadata.Tooltip = EditorUtils.MultilineTextField("Tooltip", serializableAbilityMetadata.Tooltip, 3);
         serializableAbilityMetadata.Finisher = EditorGUILayout.Toggle("Finisher", serializableAbilityMetadata.Finisher);
+        EditChannelDuration(abilityReference, serializableAbilityMetadata);
         EditAbilityOrbType(serializableAbilityMetadata);
         EditBaseAbilityData(abilityReference, serializableAbilityMetadata);
         EditGeneratedOrbs(abilityReference, serializableAbilityMetadata);
         EditAbilityBonusData(abilityReference, serializableAbilityMetadata);
             
         EditorGUI.indentLevel--;
+    }
+
+    private void EditChannelDuration(AbilityReference abilityReference, SerializableAbilityMetadata serializableAbilityMetadata)
+    {
+        if (!IsChannel(abilityReference)) return;
+
+        serializableAbilityMetadata.ChannelDuration = EditorGUILayout.FloatField(
+            "Channel Duration",
+            serializableAbilityMetadata.ChannelDuration);
+    }
+
+    private bool IsChannel(AbilityReference abilityReference)
+    {
+        Type abilityType = abilityAttributeDataLookup[abilityReference].Type;
+        return abilityType.IsSubclassOf(typeof(Channel));
     }
 
     private void EditAbilityOrbType(SerializableAbilityMetadata serializableAbilityMetadata)

--- a/Danki2/Assets/Scripts/Abilities/Lookup/SerializableAbilityMetadata.cs
+++ b/Danki2/Assets/Scripts/Abilities/Lookup/SerializableAbilityMetadata.cs
@@ -19,6 +19,8 @@ public class SerializableAbilityMetadata
     private SerializableAbilityBonusLookup abilityBonusLookup = new SerializableAbilityBonusLookup();
     [SerializeField]
     private bool finisher = false;
+    [SerializeField]
+    private float channelDuration = 0f;
 
     public string DisplayName { get => displayName; set => displayName = value; }
     public string Tooltip { get => tooltip; set => tooltip = value; }
@@ -27,6 +29,7 @@ public class SerializableAbilityMetadata
     public List<OrbType> GeneratedOrbs { get => generatedOrbs; set => generatedOrbs = value; }
     public SerializableAbilityBonusLookup AbilityBonusLookup { get => abilityBonusLookup; set => abilityBonusLookup = value; }
     public bool Finisher { get => finisher; set => finisher = value; }
+    public float ChannelDuration { get => channelDuration; set => channelDuration = value; }
 
     public bool MissingData => string.IsNullOrWhiteSpace(displayName) ||
                                string.IsNullOrWhiteSpace(tooltip) ||

--- a/Danki2/Assets/Scripts/Abilities/Lookup/SerializableMetadataLookupValidator.cs
+++ b/Danki2/Assets/Scripts/Abilities/Lookup/SerializableMetadataLookupValidator.cs
@@ -65,17 +65,37 @@ public class SerializableMetadataLookupValidator
         abilityAttributeData.ForEach(attributeData =>
         {
             Type type = attributeData.Type;
-            
-            if (!type.IsSubclassOf(typeof(InstantCast)) && !type.IsSubclassOf(typeof(Channel)))
+
+            if (type.IsSubclassOf(typeof(InstantCast)))
             {
-                LogError($"Found ability attribute on type \"{type}\", which does not inherit from a recognised ability class.");
+                ValidateInstantCast(type);
+                return;
             }
 
-            if (type.GetConstructor(new [] {typeof(Actor), typeof(AbilityData), typeof(string[])}) == null)
+            if (type.IsSubclassOf(typeof(Channel)))
             {
-                LogError($"Could not find valid ability constructor on annotated type \"{type}\".");
+                ValidateChannel(type);
+                return;
             }
+
+            LogError($"Found ability attribute on type \"{type}\", which does not inherit from a recognised ability class.");
         });
+    }
+
+    private void ValidateInstantCast(Type type)
+    {
+        if (type.GetConstructor(new[] {typeof(Actor), typeof(AbilityData), typeof(string[])}) == null)
+        {
+            LogError($"Could not find valid instant cast constructor on \"{type}\".");
+        }
+    }
+
+    private void ValidateChannel(Type type)
+    {
+        if (type.GetConstructor(new[] {typeof(Actor), typeof(AbilityData), typeof(string[]), typeof(float)}) == null)
+        {
+            LogError($"Could not find valid channel constructor on \"{type}\".");
+        }
     }
 
     private void ValidateSerializableAbilityMetadataLookup()

--- a/Danki2/Assets/Scripts/Abilities/Tooltips/Building/PlayerListTooltipBuilder.cs
+++ b/Danki2/Assets/Scripts/Abilities/Tooltips/Building/PlayerListTooltipBuilder.cs
@@ -8,7 +8,10 @@ public static class PlayerListTooltipBuilder
     {
         List<TemplatedTooltipSegment> templatedTooltipSegments = AbilityLookup.Instance.GetTemplatedTooltipSegments(ability);
 
-        return GetTooltipSegments(templatedTooltipSegments, ability);
+        List<TooltipSegment> tooltipSegments = TooltipUtils.GetTooltipPrefix(ability);
+        tooltipSegments.AddRange(GetTooltipSegments(templatedTooltipSegments, ability));
+
+        return tooltipSegments;
     }
 
     public static List<TooltipSegment> BuildBonus(AbilityReference ability, string bonus)

--- a/Danki2/Assets/Scripts/Abilities/Tooltips/Building/PlayerTreeTooltipBuilder.cs
+++ b/Danki2/Assets/Scripts/Abilities/Tooltips/Building/PlayerTreeTooltipBuilder.cs
@@ -22,7 +22,10 @@ public class PlayerTreeTooltipBuilder
     {
         List<TemplatedTooltipSegment> templatedTooltipSegments = AbilityLookup.Instance.GetTemplatedTooltipSegments(node.Ability);
 
-        return GetTooltipSegments(templatedTooltipSegments, node);
+        List<TooltipSegment> tooltipSegments = TooltipUtils.GetTooltipPrefix(node.Ability);
+        tooltipSegments.AddRange(GetTooltipSegments(templatedTooltipSegments, node));
+
+        return tooltipSegments;
     }
 
     /// <summary>

--- a/Danki2/Assets/Scripts/Abilities/Tooltips/TooltipUtils.cs
+++ b/Danki2/Assets/Scripts/Abilities/Tooltips/TooltipUtils.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+
+public static class TooltipUtils
+{
+    public static List<TooltipSegment> GetTooltipPrefix(AbilityReference abilityReference)
+    {
+        AbilityType abilityType = AbilityLookup.Instance.GetAbilityType(abilityReference);
+
+        switch (abilityType)
+        {
+            case AbilityType.InstantCast:
+                return ListUtils.Singleton(new TooltipSegment(TooltipSegmentType.Text, "Instant Cast - "));
+            case AbilityType.Channel:
+                return GetChannelPrefix(abilityReference);
+        }
+
+        return new List<TooltipSegment>();
+    }
+
+    private static List<TooltipSegment> GetChannelPrefix(AbilityReference abilityReference)
+    {
+        if (!AbilityLookup.Instance.TryGetChannelType(abilityReference, out ChannelType channelType)) return new List<TooltipSegment>();
+        if (!AbilityLookup.Instance.TryGetChannelDuration(abilityReference, out float channelDuration)) return new List<TooltipSegment>();
+
+        switch (channelType)
+        {
+            case ChannelType.Channel:
+                return ListUtils.Singleton(new TooltipSegment(TooltipSegmentType.Text, $"Channel ({channelDuration}s) - "));
+            case ChannelType.Charge:
+                return ListUtils.Singleton(new TooltipSegment(TooltipSegmentType.Text, $"Charge ({channelDuration}s) - "));
+            case ChannelType.Cast:
+                return ListUtils.Singleton(new TooltipSegment(TooltipSegmentType.Text, $"Cast ({channelDuration}s) - "));
+        }
+        
+        return new List<TooltipSegment>();
+    }
+}

--- a/Danki2/Assets/Scripts/Abilities/Tooltips/TooltipUtils.cs.meta
+++ b/Danki2/Assets/Scripts/Abilities/Tooltips/TooltipUtils.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b9a34b0415ad45b386b6bd5847630400
+timeCreated: 1604869517


### PR DESCRIPTION
- Gives every serializable ability data a channel duration field, but only uses it for actual channels.
- Also adds prefixes to ability tooltips (e.g. "Cast (2s) - " or "Instant Cast - ") through code rather than hardcoding in the editor.