### PR TITLE
Stats manager tweak

### DIFF
--- a/Danki2/Assets/Scripts/Abilities/Ability.cs
+++ b/Danki2/Assets/Scripts/Abilities/Ability.cs
@@ -25,12 +25,14 @@ public abstract class Ability
 
     protected void DealPrimaryDamage(Actor target, int linearDamageModifier = 0, int multiplicativeDamageModifier = 1)
     {
-        Owner.DamageTarget(target, GetModifiedValue(AbilityData.PrimaryDamage, linearDamageModifier, multiplicativeDamageModifier));
+        int damage = GetModifiedValue(AbilityData.PrimaryDamage, linearDamageModifier, multiplicativeDamageModifier);
+        target.HealthManager.ReceiveDamage(damage, Owner);
     }
 
     protected void DealSecondaryDamage(Actor target, int linearDamageModifier = 0, int multiplicativeDamageModifier = 1)
     {
-        Owner.DamageTarget(target, GetModifiedValue(AbilityData.SecondaryDamage, linearDamageModifier, multiplicativeDamageModifier));
+        int damage = GetModifiedValue(AbilityData.SecondaryDamage, linearDamageModifier, multiplicativeDamageModifier);
+        target.HealthManager.ReceiveDamage(damage, Owner);
     }
 
     protected void Heal(int linearHealModifier = 0, int multiplicativeHealModifier = 1)

--- a/Danki2/Assets/Scripts/Actor/Actor.cs
+++ b/Danki2/Assets/Scripts/Actor/Actor.cs
@@ -82,11 +82,6 @@ public abstract class Actor : MonoBehaviour
         return !CompareTag(target.tag);
     }
 
-    public void DamageTarget(Actor target, int damage)
-    {
-        target.HealthManager.ReceiveDamage(damage + StatsManager.Get(Stat.Power), this);
-    }
-
     public void InterruptibleAction(float delay, InterruptionType interruptionType, Action action)
     {
         Coroutine coroutine = this.WaitAndAct(delay, action);

--- a/Danki2/Assets/Scripts/Stats/StatsManager.cs
+++ b/Danki2/Assets/Scripts/Stats/StatsManager.cs
@@ -1,43 +1,30 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using UnityEngine;
 
 public class StatsManager
 {
-    private readonly StatsDictionary _baseStats;
-    private readonly Dictionary<Stat, int> _cache;
-    private List<IStatPipe> _pipes;
+    private readonly StatsDictionary baseStats;
+    private readonly Dictionary<Stat, int> cache = new Dictionary<Stat, int>();
+    private readonly List<IStatPipe> pipes = new List<IStatPipe>();
 
     public StatsManager(StatsDictionary baseStats)
     {
-        _baseStats = baseStats;
-        _cache = new Dictionary<Stat, int>();
-        _pipes = new List<IStatPipe>();
+        this.baseStats = baseStats;
     }
 
     public int Get(Stat stat)
     {
-        if (_cache.TryGetValue(stat, out int value))
-        {
-            return value;
-        }
-        else
-        {
-            float pipelineValue = _baseStats[stat];
-            _pipes.ForEach(p => pipelineValue = p.ProcessStat(stat, pipelineValue));
+        if (cache.TryGetValue(stat, out int value)) return value;
 
-            int statValue = (int)Math.Ceiling(pipelineValue);
-            _cache.Add(stat, statValue);
-            return statValue;
-        }
+        float pipelineValue = baseStats[stat];
+        pipes.ForEach(p => pipelineValue = p.ProcessStat(stat, pipelineValue));
+
+        int statValue = Mathf.CeilToInt(pipelineValue);
+        cache.Add(stat, statValue);
+        return statValue;
     }
 
-    public void RegisterPipe(IStatPipe pipe)
-    {
-        _pipes.Add(pipe);
-    }
+    public void RegisterPipe(IStatPipe pipe) => pipes.Add(pipe);
 
-    public void ClearCache()
-    {
-        _cache.Clear();
-    }
+    public void ClearCache() => cache.Clear();
 }


### PR DESCRIPTION
- Removes the DamageTarget method from Actor as we can just go directly through to the health manager. No need to add the actors power to the damage value, as this is already picked up by the AbilityDataStatsDiffer
- Updates StatsManager to be more like our other classes