### PR TITLE
Smash Radius changed to match the mpfx

### DIFF
--- a/Danki2/Assets/Scripts/Abilities/Channel/Cast/Smash.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Cast/Smash.cs
@@ -4,7 +4,7 @@
 public class Smash : Cast
 {
     private const float DistanceFromCaster = 1.8f;
-    private const float Radius = 2.05f;
+    private const float Radius = 1.6f;
     private const float PerfectSmashStunDuration = 3f;
     private const float PauseDuration = 0.3f;
 

--- a/Danki2/Assets/Scripts/Abilities/Channel/Cast/Smash.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Cast/Smash.cs
@@ -4,7 +4,7 @@
 public class Smash : Cast
 {
     private const float DistanceFromCaster = 1.8f;
-    private const float Radius = 1f;
+    private const float Radius = 2.05f;
     private const float PerfectSmashStunDuration = 3f;
     private const float PauseDuration = 0.3f;
 


### PR DESCRIPTION
Best way to check the collision template size matches:

1 - add a mesh renderer to the Cylinder CollisionTemplate, then add a material, e.g. NavBlocker_DebugMat.
2 - make changes to CollisionTemplateManager.cs as follows:
2a - comment out line 50.
2b - add a new line before 53 with "templateInstance.transform.position = position;"