### PR TITLE
Support dev scene

### DIFF
--- a/Danki2/.gitignore
+++ b/Danki2/.gitignore
@@ -53,3 +53,7 @@ fmod_editor.log
 # FMOD writes of the following lines "If the source bank files are kept outside of the StreamingAssets folder then these can be ignored."
 #/[Aa]ssets/StreamingAssets/**/*.bank
 #/[Aa]ssets/StreamingAssets/**/*.bank.meta
+
+# Dev scene - exclude an info.txt file for help adding a new scene and ensure the folder makes it to source control
+[Aa]ssets/Scenes/Dev/*
+![Aa]ssets/Scenes/Dev/info.txt

--- a/Danki2/Assets/Scenes/Dev.meta
+++ b/Danki2/Assets/Scenes/Dev.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 967f4172504fc714bb66a9c03ccc406e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Danki2/Assets/Scenes/Dev/info.txt
+++ b/Danki2/Assets/Scenes/Dev/info.txt
@@ -1,0 +1,14 @@
+The easiest way to add a dev scene is to copy an existing one. To do this:
+ - Select the scene to copy
+ - Hit ctrl-d to duplicate it
+ - Rename it as DevScene
+ - Drag it into the Scenes/Dev folder
+
+Then in the new scene:
+ - Delete the terrain gameobject which sits in Room/Level
+ - Duplicate the file called {sceneName}_TerrainData from the scene you copied and put it into Scenes/Dev (similar to earlier step)
+ - Drag the new terrain data file into the new scene and place under Room/Level
+ - Reposition the terrain to match the props
+ - Bake the navmesh by going into the Navigation tab and clicking bake
+
+ You should have a duplicated scene (missing textures on the terrain) and you shouldn't have any red lines when you do a 'git status'.


### PR DESCRIPTION
Summary:

- Add Scenes/Dev folder who's content is ignored
- Add Scenes/Dev/info.txt file which isn't ignored (by an exception to above rule)
  - This means that the Scenes/Dev folder will make it to source control and be visible to everyone
  - I've added steps for duplicating a scene into the dev folder in info.txt