### PR TITLE
Fix fmod font issue

### DIFF
--- a/Danki2/Assets/Plugins/FMOD/src/Runtime/RuntimeManager.cs
+++ b/Danki2/Assets/Plugins/FMOD/src/Runtime/RuntimeManager.cs
@@ -695,7 +695,7 @@ retry:
 
         void HandlePlayModeStateChange(PlayModeStateChange state)
         {
-            if (state == PlayModeStateChange.ExitingEditMode || state == PlayModeStateChange.EnteredEditMode)
+            if (state == PlayModeStateChange.ExitingEditMode || state == PlayModeStateChange.ExitingPlayMode)
             {
                 Destroy();
             }


### PR DESCRIPTION
It's more of a patch.

There are a clue as to what's happening though - seems like the fmod RuntimeManager is always picking up unity's built in `PlayModeStateChange.ExitingPlayMode`, however, it's not picking up the `PlayModeStateChange.EnteringEditMode` when there is a non-standard font in any text component.