### PR TITLE
Template collision method

### DIFF
--- a/Danki2/Assets/Scripts/Abilities/Ability.cs
+++ b/Danki2/Assets/Scripts/Abilities/Ability.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using FMOD.Studio;
 using UnityEngine;
 using STOP_MODE = FMOD.Studio.STOP_MODE;
+using System;
 
 public abstract class Ability
 {
@@ -67,6 +68,20 @@ public abstract class Ability
         float newAngleX = Mathf.Clamp(castAngleX, MinMeleeVerticalAngle, MaxMeleeVerticalAngle);
 
         return Quaternion.Euler(newAngleX, castRotation.eulerAngles.y, castRotation.eulerAngles.z);
+    }
+
+    protected void TemplateCollision(CollisionTemplate template, float scale, Vector3 position, Quaternion rotation, Action<Actor> offensiveAction)
+    {
+        TemplateCollision(template, scale * Vector3.one, position, rotation, offensiveAction);
+    }
+
+    protected void TemplateCollision(CollisionTemplate template, Vector3 scale, Vector3 position, Quaternion rotation, Action<Actor> offensiveAction)
+    {
+        // TODO: handle collision sounds and screenshake here?
+
+        CollisionTemplateManager.Instance.GetCollidingActors(template, scale, position, rotation)
+            .Where(actor => Owner.Opposes(actor))
+            .ForEach(offensiveAction);
     }
 
     protected void PlayStartEvent()

--- a/Danki2/Assets/Scripts/Abilities/Channel/Cast/PiercingRush.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Cast/PiercingRush.cs
@@ -58,19 +58,17 @@ public class PiercingRush : Cast
 
         bool hasDealtDamage = false;
 
-        CollisionTemplateManager.Instance.GetCollidingActors(
+        TemplateCollision(
             CollisionTemplate.Cuboid,
             collisionDetectionScale,
             collisionDetectionPosition,
-            Quaternion.LookRotation(direction)
-        ).ForEach(actor =>
-        {
-            if (Owner.Opposes(actor))
+            Quaternion.LookRotation(direction),
+            actor =>
             {
                 DealDamageDuringRush(actor, direction, dashSpeed);                
                 hasDealtDamage = true;
             }
-        });
+        );
 
         // Jetstream.
         if (HasBonus("Jetstream")) Owner.WaitAndAct(dashDuration + jetstreamCastDelay, () => Jetstream());
@@ -105,13 +103,17 @@ public class PiercingRush : Cast
 
         bool hasDealtDamage = false;
 
-        CollisionTemplateManager.Instance.GetCollidingActors(CollisionTemplate.Wedge90, jetstreamRange, Owner.transform.position, castRotation)
-            .Where(actor => Owner.Opposes(actor))
-            .ForEach(actor =>
+        TemplateCollision(
+            CollisionTemplate.Wedge90,
+            jetstreamRange,
+            Owner.transform.position,
+            castRotation,
+            actor =>
             {
                 DealPrimaryDamage(actor);
                 hasDealtDamage = true;
-            });
+            }
+        );
 
         if (hasDealtDamage) CustomCamera.Instance.AddShake(ShakeIntensity.Medium);
     }

--- a/Danki2/Assets/Scripts/Abilities/Channel/Cast/Smash.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Cast/Smash.cs
@@ -33,15 +33,19 @@ public class Smash : Cast
 
         bool hasDealtDamage = false;
 
-        CollisionTemplateManager.Instance.GetCollidingActors(CollisionTemplate.Cylinder, Radius, center)
-            .Where(actor => Owner.Opposes(actor))
-            .ForEach(actor =>
+        TemplateCollision(
+            CollisionTemplate.Cylinder,
+            Radius,
+            center,
+            Quaternion.identity,
+            actor =>
             {
                 DealPrimaryDamage(actor);
                 hasDealtDamage = true;
 
                 if (HasBonus("PerfectSmash")) actor.EffectManager.AddActiveEffect(ActiveEffect.Stun, PerfectSmashStunDuration);
-            });
+            }
+        );
 
         CustomCamera.Instance.AddShake(ShakeIntensity.High);
         SmashObject.Create(center);

--- a/Danki2/Assets/Scripts/Abilities/Channel/Channel/BearCharge.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Channel/BearCharge.cs
@@ -62,20 +62,18 @@ public class BearCharge : Channel
     {
         bool hasDealtDamage = false;
 
-        CollisionTemplateManager.Instance.GetCollidingActors(
+        TemplateCollision(
             CollisionTemplate.Wedge90,
             DamageRadius,
             Owner.CollisionTemplateSource,
-            Quaternion.LookRotation(Owner.transform.forward)
-        ).ForEach(actor =>
-        {
-            if (Owner.Opposes(actor))
+            Quaternion.LookRotation(Owner.transform.forward),
+            actor =>
             {
                 KnockBack(actor);
                 DealPrimaryDamage(actor);
                 hasDealtDamage = true;
             }
-        });
+        );
 
         chargeObject.CreateSwipe(
             Owner.AbilitySource,

--- a/Danki2/Assets/Scripts/Abilities/Channel/Channel/Reflect.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Channel/Reflect.cs
@@ -40,11 +40,19 @@ public class Reflect : Channel
 
     private void HandleIncomingDamage(DamageData damageData)
     {
-        List<Actor> collidingActors = CollisionTemplateManager.Instance
-            .GetCollidingActors(CollisionTemplate.Wedge90, Range, Owner.transform.position, Owner.transform.rotation)
-            .Where(actor => Owner.Opposes(actor));
+        bool damageSourceInRange = false;
 
-        if (!collidingActors.Contains(damageData.Source)) return;
+        TemplateCollision(
+            CollisionTemplate.Wedge90,
+            Range,
+            Owner.transform.position,
+            Owner.transform.rotation,
+            actor => {
+                if (actor == damageData.Source) damageSourceInRange = true;
+            }
+        );
+
+        if (!damageSourceInRange) return;
 
         if (!receivedDamage) SuccessFeedbackSubject.Next(true);
         receivedDamage = true;

--- a/Danki2/Assets/Scripts/Abilities/Channel/Channel/Whirlwind.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Channel/Whirlwind.cs
@@ -57,13 +57,17 @@ public class Whirlwind : Channel
     {
         bool actorsHit = false;
 
-        CollisionTemplateManager.Instance.GetCollidingActors(CollisionTemplate.Cylinder, radius, Owner.transform.position, Quaternion.identity)
-            .Where(actor => actor.Opposes(Owner))
-            .ForEach(actor =>
+        TemplateCollision(
+            CollisionTemplate.Cylinder,
+            radius,
+            Owner.transform.position,
+            Quaternion.identity,
+            actor =>
             {
                 damageAction(actor);
                 actorsHit = true;
-            });
+            }
+        );
 
         if (actorsHit)
         {

--- a/Danki2/Assets/Scripts/Abilities/InstantCast/Bash.cs
+++ b/Danki2/Assets/Scripts/Abilities/InstantCast/Bash.cs
@@ -27,14 +27,18 @@ public class Bash : InstantCast
 
         bool hasDealtDamage = false;
 
-        CollisionTemplateManager.Instance.GetCollidingActors(CollisionTemplate.Cylinder, Radius, center)
-            .Where(actor => Owner.Opposes(actor))
-            .ForEach(actor =>
+        TemplateCollision(
+            CollisionTemplate.Cylinder,
+            Radius,
+            center,
+            Quaternion.identity,
+            actor =>
             {
                 DealPrimaryDamage(actor);
                 actor.EffectManager.AddActiveEffect(ActiveEffect.Stun, StunDuration);
                 hasDealtDamage = true;
-            });
+            }
+        );
 
         SuccessFeedbackSubject.Next(hasDealtDamage);
         

--- a/Danki2/Assets/Scripts/Abilities/InstantCast/Bite.cs
+++ b/Danki2/Assets/Scripts/Abilities/InstantCast/Bite.cs
@@ -23,13 +23,17 @@ public class Bite : InstantCast
 
         bool hasDealtDamage = false;
 
-        CollisionTemplateManager.Instance.GetCollidingActors(CollisionTemplate.Wedge45, Range, Owner.CollisionTemplateSource, castRotation)
-            .Where(actor => Owner.Opposes(actor))
-            .ForEach(actor =>
+        TemplateCollision(
+            CollisionTemplate.Wedge45,
+            Range,
+            Owner.CollisionTemplateSource,
+            castRotation,
+            actor =>
             {
                 DealPrimaryDamage(actor);
                 hasDealtDamage = true;
-            });
+            }
+        );
 
         if (hasDealtDamage)
         {

--- a/Danki2/Assets/Scripts/Abilities/InstantCast/Cleave.cs
+++ b/Danki2/Assets/Scripts/Abilities/InstantCast/Cleave.cs
@@ -22,14 +22,18 @@ public class Cleave : InstantCast
 
         bool hasDealtDamage = false;
 
-        CollisionTemplateManager.Instance.GetCollidingActors(CollisionTemplate.Wedge180, Range, Owner.CollisionTemplateSource, castRotation)
-            .Where(actor => Owner.Opposes(actor))
-            .ForEach(actor =>
+        TemplateCollision(
+            CollisionTemplate.Wedge180,
+            Range,
+            Owner.CollisionTemplateSource,
+            castRotation,
+            actor =>
             {
                 DealPrimaryDamage(actor);
                 KnockBack(actor);
                 hasDealtDamage = true;
-            });
+            }
+        );
 
         SuccessFeedbackSubject.Next(hasDealtDamage);
 

--- a/Danki2/Assets/Scripts/Abilities/InstantCast/Disengage.cs
+++ b/Danki2/Assets/Scripts/Abilities/InstantCast/Disengage.cs
@@ -36,18 +36,17 @@ public class Disengage : InstantCast
 
         bool dealtDamage = false;
 
-        CollisionTemplateManager.Instance.GetCollidingActors(
+        TemplateCollision(
             CollisionTemplate.Cylinder,
             partingShotRange,
-            position
-        ).ForEach(actor =>
-        {
-            if (Owner.Opposes(actor))
+            position,
+            Quaternion.identity,
+            actor =>
             {
                 DealPrimaryDamage(actor);
                 dealtDamage = true;
             }
-        });
+        );
 
         SuccessFeedbackSubject.Next(dealtDamage);
     }

--- a/Danki2/Assets/Scripts/Abilities/InstantCast/Lunge.cs
+++ b/Danki2/Assets/Scripts/Abilities/InstantCast/Lunge.cs
@@ -46,14 +46,18 @@ public class Lunge : InstantCast
 
         bool hasDealtDamage = false;
 
-        CollisionTemplateManager.Instance.GetCollidingActors(CollisionTemplate.Wedge90, StunRange, Owner.CollisionTemplateSource, castRotation)
-            .Where(actor => actor.Opposes(Owner))
-            .ForEach(actor =>
+        TemplateCollision(
+            CollisionTemplate.Wedge90,
+            StunRange,
+            Owner.CollisionTemplateSource,
+            castRotation,
+            actor =>
             {
                 actor.EffectManager.AddActiveEffect(ActiveEffect.Stun, StunDuration);
                 DealPrimaryDamage(actor);
                 hasDealtDamage = true;
-            });
+            }
+        );
 
         SuccessFeedbackSubject.Next(hasDealtDamage);
         Owner.MovementManager.Pause(PauseDuration);

--- a/Danki2/Assets/Scripts/Abilities/InstantCast/Maul.cs
+++ b/Danki2/Assets/Scripts/Abilities/InstantCast/Maul.cs
@@ -36,14 +36,18 @@ public class Maul : InstantCast
 
         bool hasDealtDamage = false;
 
-        CollisionTemplateManager.Instance.GetCollidingActors(CollisionTemplate.Wedge45, BiteRange, Owner.CollisionTemplateSource, castRotation)
-            .Where(actor => Owner.Opposes(actor))
-            .ForEach(actor =>
+        TemplateCollision(
+            CollisionTemplate.Wedge45,
+            BiteRange,
+            Owner.CollisionTemplateSource,
+            castRotation,
+            actor =>
             {
                 DealPrimaryDamage(actor);
                 actor.EffectManager.AddActiveEffect(ActiveEffect.Slow, SlowDuration);
                 hasDealtDamage = true;
-            });
+            }
+        );
 
         if (hasDealtDamage)
         {

--- a/Danki2/Assets/Scripts/Abilities/InstantCast/Pounce.cs
+++ b/Danki2/Assets/Scripts/Abilities/InstantCast/Pounce.cs
@@ -36,19 +36,17 @@ public class Pounce : InstantCast
     {
         bool hasDealtDamage = false;
 
-        CollisionTemplateManager.Instance.GetCollidingActors(
+        TemplateCollision(
             CollisionTemplate.Wedge90,
             DamageRadius,
             Owner.CollisionTemplateSource,
-            Quaternion.LookRotation(Owner.transform.forward)
-        ).ForEach(actor =>
-        {
-            if (Owner.Opposes(actor))
+            Quaternion.LookRotation(Owner.transform.forward),
+            actor =>
             {
                 DealPrimaryDamage(actor);
                 hasDealtDamage = true;
             }
-        });
+        );
 
         BiteObject.Create(Owner.AbilitySource, Quaternion.LookRotation(Owner.transform.forward));
 

--- a/Danki2/Assets/Scripts/Abilities/InstantCast/Slash.cs
+++ b/Danki2/Assets/Scripts/Abilities/InstantCast/Slash.cs
@@ -18,13 +18,17 @@ public class Slash : InstantCast
 
         bool hasDealtDamage = false;
 
-        CollisionTemplateManager.Instance.GetCollidingActors(CollisionTemplate.Wedge90, Range, Owner.CollisionTemplateSource, castRotation)
-            .Where(actor => Owner.Opposes(actor))
-            .ForEach(actor =>
+        TemplateCollision(
+            CollisionTemplate.Wedge90,
+            Range,
+            Owner.CollisionTemplateSource,
+            castRotation,
+            actor =>
             {
                 DealPrimaryDamage(actor);
                 hasDealtDamage = true;
-            });
+            }
+        );
 
         SuccessFeedbackSubject.Next(hasDealtDamage);
 

--- a/Danki2/Assets/Scripts/Abilities/InstantCast/SweepingStrike.cs
+++ b/Danki2/Assets/Scripts/Abilities/InstantCast/SweepingStrike.cs
@@ -21,14 +21,18 @@ public class SweepingStrike : InstantCast
 
         bool hasDealtDamage = false;
 
-        CollisionTemplateManager.Instance.GetCollidingActors(CollisionTemplate.Wedge90, Range, Owner.CollisionTemplateSource, castRotation)
-            .Where(actor => Owner.Opposes(actor))
-            .ForEach(actor =>
+        TemplateCollision(
+            CollisionTemplate.Wedge90,
+            Range,
+            Owner.CollisionTemplateSource,
+            castRotation,
+            actor =>
             {
                 DealPrimaryDamage(actor);
                 hasDealtDamage = true;
                 KnockBack(actor);
-            });
+            }
+        );
 
         SuccessFeedbackSubject.Next(hasDealtDamage);
 

--- a/Danki2/Assets/Scripts/Abilities/InstantCast/Swipe.cs
+++ b/Danki2/Assets/Scripts/Abilities/InstantCast/Swipe.cs
@@ -32,19 +32,17 @@ public class Swipe : InstantCast
     {
         bool hasDealtDamage = false;
 
-        CollisionTemplateManager.Instance.GetCollidingActors(
+        TemplateCollision(
             CollisionTemplate.Wedge90,
             DamageRadius,
             Owner.CollisionTemplateSource,
-            Quaternion.LookRotation(Owner.transform.forward)
-        ).ForEach(actor =>
-        {
-            if (Owner.Opposes(actor))
+            Quaternion.LookRotation(Owner.transform.forward),
+            actor =>
             {
                 DealPrimaryDamage(actor);
                 hasDealtDamage = true;
             }
-        });
+        );
 
         SwipeObject swipeObject = SwipeObject.Create(
             Owner.AbilitySource,

--- a/Danki2/Assets/Scripts/Abilities/InstantCast/Swipe.cs
+++ b/Danki2/Assets/Scripts/Abilities/InstantCast/Swipe.cs
@@ -52,9 +52,6 @@ public class Swipe : InstantCast
         Owner.MovementManager.Pause(PauseDuration);
         SuccessFeedbackSubject.Next(hasDealtDamage);
 
-        if (hasDealtDamage)
-        {
-            CustomCamera.Instance.AddShake(ShakeIntensity.Medium);
-        }
+        if (hasDealtDamage) CustomCamera.Instance.AddShake(ShakeIntensity.Medium);
     }
 }

--- a/Danki2/Assets/Scripts/CollisionDetection/CollisionTemplateManager.cs
+++ b/Danki2/Assets/Scripts/CollisionDetection/CollisionTemplateManager.cs
@@ -25,20 +25,6 @@ public class CollisionTemplateManager : Singleton<CollisionTemplateManager>
         }
     }
 
-    public List<Actor> GetCollidingActors(CollisionTemplate template, float scale, Vector3 position) {
-        return GetCollidingActors(template, scale, position, Quaternion.identity);
-    }
-
-    public List<Actor> GetCollidingActors(CollisionTemplate template, float scale, Vector3 position, Quaternion rotation)
-    {
-        Vector3 scaleFactor = Vector3.one * scale;
-        return GetCollidingActors(template, scaleFactor, position, rotation);
-    }
-
-    public List<Actor> GetCollidingActors(CollisionTemplate template, Vector3 scale, Vector3 position) {
-        return GetCollidingActors(template, scale, position, Quaternion.identity);
-    }
-
     public List<Actor> GetCollidingActors(CollisionTemplate template, Vector3 scale, Vector3 position, Quaternion rotation)
     {
         MeshCollider templateInstance = instanceLookup[template];


### PR DESCRIPTION
I think this neatens things up nicely in our abilities.

Will also make it easier to plug in an ability collision sound template along the lines of this ticket https://trello.com/c/f4m6Hli3/2-collision-sound-proposal. We'll be able to add a new parameter into TemplateCollision that determines the size parameter of collision fmod events. Something like:
```c#
public enum ImpactSize
{
   None,
   Small,
   Large
}
```
Where none means no collision sounds, small means 0 in the size parameter and large means 1 in the size parameter.