### PR TITLE
add damage pipes and make reflect directional

### DIFF
--- a/Danki2/Assets/Scripts/Abilities/Channel/Channel/Parry.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Channel/Parry.cs
@@ -15,14 +15,14 @@ public class Parry : Channel
     {
         ParryObject.Create(Owner.transform, onParry);
 
-        damagePipeId = Owner.HealthManager.RegisterDamagePipe(BlockDamage);
+        damagePipeId = Owner.HealthManager.RegisterDamagePipe(DamagePipe);
     }
 
     public override void Cancel(Vector3 floorTargetPosition, Vector3 offsetTargetPosition) => Finish();
 
     public override void End(Vector3 floorTargetPosition, Vector3 offsetTargetPosition) => Finish();
 
-    private bool BlockDamage(DamageData damageData)
+    private bool DamagePipe(DamageData damageData)
     {
         onParry.Next();
         

--- a/Danki2/Assets/Scripts/Abilities/Channel/Channel/Parry.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Channel/Parry.cs
@@ -6,42 +6,37 @@ public class Parry : Channel
 {
     private const float reflectedDamageProportion = 0.5f;
     
-    private Subscription<DamageData> damageSourceSubscription;
+    private Guid damagePipeId;
     private readonly Subject onParry = new Subject();
-
-    private bool receivedDamage = false;
-    private Guid effectId;
 
     public Parry(AbilityConstructionArgs arguments) : base(arguments) { }
 
     public override void Start(Vector3 floorTargetPosition, Vector3 offsetTargetPosition)
     {
         ParryObject.Create(Owner.transform, onParry);
-        
-        Owner.EffectManager.TryAddPassiveEffect(PassiveEffect.Block, out effectId);
-        
-        damageSourceSubscription = Owner.HealthManager.UnmodifiedDamageSubject.Subscribe(HandleIncomingDamage);
+
+        damagePipeId = Owner.HealthManager.RegisterDamagePipe(BlockDamage);
     }
 
     public override void Cancel(Vector3 floorTargetPosition, Vector3 offsetTargetPosition) => Finish();
 
     public override void End(Vector3 floorTargetPosition, Vector3 offsetTargetPosition) => Finish();
 
-    private void HandleIncomingDamage(DamageData damageData)
+    private bool BlockDamage(DamageData damageData)
     {
         onParry.Next();
         
-        if (!receivedDamage) SuccessFeedbackSubject.Next(true);
-        receivedDamage = true;
+        SuccessFeedbackSubject.Next(true);
 
         int damage = Mathf.FloorToInt(damageData.Damage * reflectedDamageProportion);
         DealPrimaryDamage(damageData.Source, damage);
+
+        return false;
     }
 
     private void Finish()
     {
-        Owner.EffectManager.RemovePassiveEffect(effectId);
-        damageSourceSubscription.Unsubscribe();
-        if (!receivedDamage) SuccessFeedbackSubject.Next(false);
+        Owner.HealthManager.DeregisterDamagePipe(damagePipeId);
+        SuccessFeedbackSubject.Next(false);
     }
 }

--- a/Danki2/Assets/Scripts/Abilities/Channel/Channel/Reflect.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Channel/Reflect.cs
@@ -19,7 +19,7 @@ public class Reflect : Channel
     public override void Start(Vector3 floorTargetPosition, Vector3 offsetTargetPosition)
     {
         reflectObject = ReflectObject.Create(Owner.transform, Owner.Height, onReflect, VisualPositionOffset);
-        damagePipeId = Owner.HealthManager.RegisterDamagePipe(BlockDirectionalDamage);
+        damagePipeId = Owner.HealthManager.RegisterDamagePipe(DamagePipe);
     }
 
     public override void Continue(Vector3 floorTargetPosition, Vector3 offsetTargetPosition)
@@ -31,7 +31,7 @@ public class Reflect : Channel
 
     public override void End(Vector3 floorTargetPosition, Vector3 offsetTargetPosition) => Finish();
 
-    private bool BlockDirectionalDamage(DamageData damageData)
+    private bool DamagePipe(DamageData damageData)
     {
         bool damageSourceInRange = false;
 

--- a/Danki2/Assets/Scripts/Abilities/Channel/Channel/Reflect.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Channel/Reflect.cs
@@ -6,7 +6,6 @@ public class Reflect : Channel
 {
     private const float Range = 3;
     private const float VisualPositionOffset = 0.7f;
-    private const float MaxReflectAngle = 45; // Note that this value is tied to the collision template we use
 
     private ReflectObject reflectObject;
 
@@ -54,12 +53,7 @@ public class Reflect : Channel
             DealPrimaryDamage(damageData.Source, damageData.Damage);
         }
 
-        float angle = Vector3.Angle(
-            Owner.transform.forward,
-            damageData.Source.transform.position - Owner.transform.position
-        );
-
-        return angle > MaxReflectAngle;
+        return !damageSourceInRange;
     }
 
     private void Finish()

--- a/Danki2/Assets/Scripts/Actor/Services/Health/HealthManager.cs
+++ b/Danki2/Assets/Scripts/Actor/Services/Health/HealthManager.cs
@@ -104,6 +104,11 @@ public class HealthManager
         }
     }
 
+    /// <summary>
+    /// Register a pipe that damage data is passed through. Returning false will cause the damage to be blocked.
+    /// </summary>
+    /// <param name="pipe"></param>
+    /// <returns></returns>
     public Guid RegisterDamagePipe(Func<DamageData, bool> pipe) => damagePipeRegistry.AddIndefinite(pipe);
 
     public void DeregisterDamagePipe(Guid pipeId) => damagePipeRegistry.Remove(pipeId);


### PR DESCRIPTION
I didn't add pipes for effects/block them in parry & reflect. It would be harder to do it cleanly.

I think we should dick about with parry and reflect as they are and see if we really need to extend to effects.