### PR TITLE
Scene lookup test

### DIFF
--- a/Danki2/Assets/Tests/Scenes.meta
+++ b/Danki2/Assets/Tests/Scenes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 97d45947bc2867e4097a93cca26ba969
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Danki2/Assets/Tests/Scenes/SceneLookupTest.cs
+++ b/Danki2/Assets/Tests/Scenes/SceneLookupTest.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
+using UnityEngine;
 using UnityEngine.TestTools;
 
 public class SceneLookupTest
@@ -26,6 +27,8 @@ public class SceneLookupTest
         SceneLookup sceneLookup = TestUtils.InstantiatePrefab<SceneLookup>(SceneLookupAssetPath);
         MapGenerationLookup mapGenerationLookup = TestUtils.InstantiatePrefab<MapGenerationLookup>(MapGenerationLookupAssetPath);
         
+        bool hasInvalidConfigurations = false;
+
         EnumUtils.ForEach<RoomType>(roomType =>
         {
             if (roomTypesToIgnore.Contains(roomType)) return;
@@ -37,17 +40,22 @@ public class SceneLookupTest
                 for (int numberOfExits = mapGenerationLookup.MinRoomExits; numberOfExits <= mapGenerationLookup.MaxRoomExits; numberOfExits++)
                 {
                     List<Scene> validScenes = sceneLookup.GetValidScenes(roomType, trueEntranceDirection, numberOfExits);
-                    Assert.Greater(
-                        validScenes.Count,
-                        0,
+                    
+                    if (validScenes.Count > 0) continue;
+                    
+                    hasInvalidConfigurations = true;
+                    Debug.Log(
                         $"RoomType: {roomType}, " +
                         $"TrueEntranceDirection: {trueEntranceDirection}, " +
-                        $"NumberOfExists: {numberOfExits} " +
+                        $"NumberOfExits: {numberOfExits} " +
                         "has no valid scenes. Ensure that there is a scene that accommodates this configuration."
                     );
                 }
+                
             });
         });
+
+        Assert.False(hasInvalidConfigurations, "Found invalid room configurations, see console for more info.");
         
         yield return null;
     }

--- a/Danki2/Assets/Tests/Scenes/SceneLookupTest.cs
+++ b/Danki2/Assets/Tests/Scenes/SceneLookupTest.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+public class SceneLookupTest
+{
+    private const string SceneLookupAssetPath = "Assets/Prefabs/Meta/SceneLookup.prefab";
+    private const string MapGenerationLookupAssetPath = "Assets/Prefabs/Meta/MapGenerationLookup.prefab";
+    
+    private readonly ISet<RoomType> roomTypesToIgnore = new HashSet<RoomType>
+    {
+        RoomType.Victory,
+        RoomType.Defeat,
+        // RoomType.Shop, // TODO: Remove this once we are supporting shop rooms.
+    };
+    
+    private readonly ISet<Pole> trueEntranceDirectionsToIgnore = new HashSet<Pole>
+    {
+        Pole.North,
+    };
+
+    [UnityTest]
+    public IEnumerator TestSceneLookupContainsAllPossibleRoomConfigurations()
+    {
+        SceneLookup sceneLookup = TestUtils.InstantiatePrefab<SceneLookup>(SceneLookupAssetPath);
+        MapGenerationLookup mapGenerationLookup = TestUtils.InstantiatePrefab<MapGenerationLookup>(MapGenerationLookupAssetPath);
+        
+        EnumUtils.ForEach<RoomType>(roomType =>
+        {
+            if (roomTypesToIgnore.Contains(roomType)) return;
+            
+            EnumUtils.ForEach<Pole>(trueEntranceDirection =>
+            {
+                if (trueEntranceDirectionsToIgnore.Contains(trueEntranceDirection)) return;
+
+                for (int numberOfExits = mapGenerationLookup.MinRoomExits; numberOfExits <= mapGenerationLookup.MaxRoomExits; numberOfExits++)
+                {
+                    List<Scene> validScenes = sceneLookup.GetValidScenes(roomType, trueEntranceDirection, numberOfExits);
+                    Assert.Greater(
+                        validScenes.Count,
+                        0,
+                        $"RoomType: {roomType}, " +
+                        $"TrueEntranceDirection: {trueEntranceDirection}, " +
+                        $"NumberOfExists: {numberOfExits} " +
+                        "has no valid scenes. Ensure that there is a scene that accommodates this configuration."
+                    );
+                }
+            });
+        });
+        
+        yield return null;
+    }
+}

--- a/Danki2/Assets/Tests/Scenes/SceneLookupTest.cs
+++ b/Danki2/Assets/Tests/Scenes/SceneLookupTest.cs
@@ -12,7 +12,7 @@ public class SceneLookupTest
     {
         RoomType.Victory,
         RoomType.Defeat,
-        // RoomType.Shop, // TODO: Remove this once we are supporting shop rooms.
+        RoomType.Shop, // TODO: Remove this once we are supporting shop rooms.
     };
     
     private readonly ISet<Pole> trueEntranceDirectionsToIgnore = new HashSet<Pole>

--- a/Danki2/Assets/Tests/Scenes/SceneLookupTest.cs.meta
+++ b/Danki2/Assets/Tests/Scenes/SceneLookupTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: be6c492246b2b9c46b8d9c03d50dad24
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Danki2/Assets/Tests/TestUtils.cs
+++ b/Danki2/Assets/Tests/TestUtils.cs
@@ -1,0 +1,11 @@
+using UnityEditor;
+using UnityEngine;
+
+public static class TestUtils
+{
+    public static T InstantiatePrefab<T>(string assetPath) where T : Object
+    {
+        T prefab = AssetDatabase.LoadAssetAtPath<T>(assetPath);
+        return Object.Instantiate(prefab);
+    }
+}

--- a/Danki2/Assets/Tests/TestUtils.cs.meta
+++ b/Danki2/Assets/Tests/TestUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f67cdf8004be674ebcd91a39e7848c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds a test that fails if there are possible room configurations that won't have any valid scenes. This means that we'll be able to confidently get rid of the catch all scene, even if we don't have any individual scenes that can handle every layout.

The test runs in the Unity cloud build and the build will fail if the test fails. I've tested this out with a failing and passing version of this branch and it all works as expected.