### PR TITLE
Bear ai improvements

### DIFF
--- a/Danki2/Assets/Prefabs/Enemies/Bear1.prefab
+++ b/Danki2/Assets/Prefabs/Enemies/Bear1.prefab
@@ -447,13 +447,13 @@ MonoBehaviour:
   minAdvanceRange: 3
   maxAttackRange: 4.5
   maxChargeRange: 10
-  chargeInterval: 4
+  chargeMinInterval: 3
+  chargeMaxInterval: 5
   chargeRecoveryTime: 2
-  minRunDistance: 6
   swipeDelay: 0.5
   chargeDelay: 0.5
   maulDelay: 0.5
-  cleaveDelay: 1
+  cleaveDelay: 1.3
   abilityInterval: 2
   maxAttackAngle: 10
 --- !u!195 &1307004630582523634

--- a/Danki2/Assets/Prefabs/Enemies/Bear1.prefab
+++ b/Danki2/Assets/Prefabs/Enemies/Bear1.prefab
@@ -430,6 +430,7 @@ MonoBehaviour:
   centre: {fileID: 7817277397840590268}
   abilitySource: {fileID: 2501541229603721505}
   collisionTemplateSource: {fileID: 7496201845270352354}
+  roarEvent: event:/SX_NPC/SX_Bear/SX_Bear_Roar
 --- !u!114 &3495619026043065561
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Danki2/Assets/Scripts/AI/AIs/BearAi.cs
+++ b/Danki2/Assets/Scripts/AI/AIs/BearAi.cs
@@ -9,11 +9,9 @@ public class BearAi : Ai
     [SerializeField, Tooltip("Value must be less than maxAttackRange.")] private float minAdvanceRange = 0;
     [SerializeField, Tooltip("Value must be greater than minAdvanceRange.")] private float maxAttackRange = 0;
     [SerializeField] private float maxChargeRange = 0;
-    [SerializeField] private float chargeInterval = 0;
+    [SerializeField] private float chargeMinInterval = 0;
+    [SerializeField] private float chargeMaxInterval = 0;
     [SerializeField] private float chargeRecoveryTime = 0;
-
-    [Header("Advance")]
-    [SerializeField] private float minRunDistance = 0;
 
     [Header("Attack")]
     [SerializeField] private float swipeDelay = 0;
@@ -32,13 +30,13 @@ public class BearAi : Ai
         IStateMachineComponent advanceStateMachine = new StateMachine<AdvanceState>(AdvanceState.Walk)
             .WithComponent(AdvanceState.Walk, new WalkTowards(bear, player))
             .WithComponent(AdvanceState.Run, new MoveTowards(bear, player))
-            .WithTransition(AdvanceState.Walk, AdvanceState.Run, new DistanceGreaterThan(bear, player, minRunDistance) | new TakesNonTickDamage(bear));
+            .WithTransition(AdvanceState.Walk, AdvanceState.Run, new TakesNonTickDamage(bear));
 
         IStateMachineComponent attackStateMachine = new StateMachine<AttackState>(AttackState.ChooseAbility)
             .WithComponent(AttackState.WatchTarget, new WatchTarget(bear, player))
             .WithComponent(AttackState.TelegraphSwipe, new TelegraphAttack(bear, Color.red))
             .WithComponent(AttackState.TelegraphMaul, new TelegraphAttack(bear, Color.green))
-            .WithComponent(AttackState.TelegraphCleave, new TelegraphAttack(bear, Color.yellow))
+            .WithComponent(AttackState.TelegraphCleave, new TelegraphAttackAndWatch(bear, player, Color.yellow))
             .WithComponent(AttackState.Swipe, new BearSwipe(bear))
             .WithComponent(AttackState.Maul, new BearMaul(bear))
             .WithComponent(AttackState.Cleave, new BearCleave(bear))
@@ -64,7 +62,7 @@ public class BearAi : Ai
             .WithTransition(State.Idle, State.Advance, new DistanceLessThan(bear, player, aggroDistance) | new TakesDamage(bear))
             .WithTransition(State.Advance, State.Attack, new DistanceLessThan(bear, player, minAdvanceRange) & new Facing(bear, player, maxAttackAngle))
             .WithTransition(State.Attack, State.Advance, new DistanceGreaterThan(bear, player, maxAttackRange) & !new IsTelegraphing(bear))
-            .WithTransition(State.Advance, State.TelegraphCharge, new DistanceLessThan(bear, player, maxChargeRange) & new TimeElapsed(chargeInterval))
+            .WithTransition(State.Advance, State.TelegraphCharge, new DistanceLessThan(bear, player, maxChargeRange) & new RandomTimeElapsed(chargeMinInterval, chargeMaxInterval))
             .WithTransition(State.TelegraphCharge, State.Charge, new CastableTimeElapsed(bear, chargeDelay))
             .WithTransition(State.Charge, State.Watch, new ChannelComplete(bear))
             .WithTransition(State.Watch, State.Advance, new TimeElapsed(chargeRecoveryTime));

--- a/Danki2/Assets/Scripts/Actor/Enemy/Bear.cs
+++ b/Danki2/Assets/Scripts/Actor/Enemy/Bear.cs
@@ -4,8 +4,7 @@ using UnityEngine;
 
 public class Bear : Enemy
 {
-    [EventRef]
-    [SerializeField]
+    [EventRef, SerializeField]
     private string roarEvent = null;
 
     private bool canRoar = true;
@@ -13,9 +12,7 @@ public class Bear : Enemy
 
     public override ActorType Type => ActorType.Bear;
 
-    public Subject MaulAndSwipeSubject { get; set; } = new Subject();
-
-    public Subject CleaveSubject { get; set; } = new Subject();
+    public Subject CleaveSubject { get; } = new Subject();
 
     protected override void Start()
     {
@@ -46,8 +43,6 @@ public class Bear : Enemy
             GetMeleeTargetPosition(transform.position),
             GetMeleeTargetPosition(Centre)
         );
-
-        MaulAndSwipeSubject.Next();
     }
 
     public void Charge()
@@ -62,8 +57,6 @@ public class Bear : Enemy
             GetMeleeTargetPosition(transform.position),
             GetMeleeTargetPosition(Centre)
         );
-
-        MaulAndSwipeSubject.Next();
     }
 
     public void Cleave()

--- a/Danki2/Assets/Scripts/Actor/Enemy/Bear.cs
+++ b/Danki2/Assets/Scripts/Actor/Enemy/Bear.cs
@@ -2,6 +2,10 @@
 {
     public override ActorType Type => ActorType.Bear;
 
+    public Subject MaulAndSwipeSubject { get; set; } = new Subject();
+
+    public Subject CleaveSubject { get; set; } = new Subject();
+
     public void Swipe()
     {
         InstantCastService.TryCast(
@@ -9,6 +13,8 @@
             GetMeleeTargetPosition(transform.position),
             GetMeleeTargetPosition(Centre)
         );
+
+        MaulAndSwipeSubject.Next();
     }
 
     public void Charge()
@@ -23,6 +29,8 @@
             GetMeleeTargetPosition(transform.position),
             GetMeleeTargetPosition(Centre)
         );
+
+        MaulAndSwipeSubject.Next();
     }
 
     public void Cleave()
@@ -32,5 +40,7 @@
             GetMeleeTargetPosition(transform.position),
             GetMeleeTargetPosition(Centre)
         );
+
+        CleaveSubject.Next();
     }
 }

--- a/Danki2/Assets/Scripts/Actor/Enemy/Bear.cs
+++ b/Danki2/Assets/Scripts/Actor/Enemy/Bear.cs
@@ -1,10 +1,43 @@
-﻿public class Bear : Enemy
+﻿using FMOD.Studio;
+using FMODUnity;
+using UnityEngine;
+
+public class Bear : Enemy
 {
+    [EventRef]
+    [SerializeField]
+    private string roarEvent = null;
+
+    private bool canRoar = true;
+    private float roarDuration;
+
     public override ActorType Type => ActorType.Bear;
 
     public Subject MaulAndSwipeSubject { get; set; } = new Subject();
 
     public Subject CleaveSubject { get; set; } = new Subject();
+
+    protected override void Start()
+    {
+        base.Start();
+
+        roarDuration = FmodUtils.GetDuration(roarEvent);
+
+        HealthManager.ModifiedDamageSubject.Subscribe(_ => Roar());
+    }
+
+    public void Roar()
+    {
+        if (!canRoar) return;
+
+        canRoar = false;
+
+        this.WaitAndAct(roarDuration, () => canRoar = true);
+
+        EventInstance fmodEvent = FmodUtils.CreatePositionedInstance(roarEvent, transform.position);
+        fmodEvent.start();
+        fmodEvent.release();
+    }
 
     public void Swipe()
     {

--- a/Danki2/Assets/Scripts/StateMachine/Deciders/RandomDecider.cs
+++ b/Danki2/Assets/Scripts/StateMachine/Deciders/RandomDecider.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+public class RandomDecider<TState> : IStateMachineDecider<TState> where TState : Enum
+{
+    private readonly TState[] options;
+
+    public RandomDecider(params TState[] options)
+    {
+        this.options = options;
+    }
+
+    public TState Decide()
+    {
+        return RandomUtils.Choice(options);
+    }
+}

--- a/Danki2/Assets/Scripts/StateMachine/Deciders/RandomDecider.cs.meta
+++ b/Danki2/Assets/Scripts/StateMachine/Deciders/RandomDecider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3407205c2a424464e8610645ec4deb1c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Danki2/Assets/Scripts/Utils/FmodUtils.cs
+++ b/Danki2/Assets/Scripts/Utils/FmodUtils.cs
@@ -11,4 +11,13 @@ public static class FmodUtils
 
         return eventInstance;
     }
+
+    public static float GetDuration(string fmodEvent)
+    {
+        EventDescription description = RuntimeManager.GetEventDescription(fmodEvent);
+
+        description.getLength(out int durationMilliseconds);
+
+        return (float)durationMilliseconds / 1000;
+    }
 }


### PR DESCRIPTION
To summarize the changes:

- The bear can cast cleave throughout combat
- The bear watches the player while telegraphing cleave so the player is forced to dash backwards (it has an even longer telegraph time accordingly)
- The bear telegraphs and executes a charge directly after cleaving
- The bear will always walk toward the player unless charging or damaged while walking
- Bear roar plugged into taking non-ticking damage (I tried plugging it into abilities but it doesn't sound right there as it's more of a moan)

Note that I had to rebuild the fmod project as it's hadn't been built since the bear sounds were added. We had agreed not to modify the fmod project, but this seems safe as the master.bank file is likely recreated each build. Worst case scenario Ben could just delete it and rebuild (I tested this).