### PR TITLE
Sets associated entrances to transitions 3 and 4

### DIFF
--- a/Danki2/Assets/Scenes/GameplayScenes/ForestClearingScene/ForestClearingScene.unity
+++ b/Danki2/Assets/Scenes/GameplayScenes/ForestClearingScene/ForestClearingScene.unity
@@ -3573,8 +3573,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   type: 1
-  hasAssociatedEntrance: 0
-  associatedEntranceId: 0
+  hasAssociatedEntrance: 1
+  associatedEntranceId: 2
   hasAssociatedExit: 1
   associatedExitId: 2
 --- !u!1001 &392154814
@@ -14406,8 +14406,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   type: 1
-  hasAssociatedEntrance: 0
-  associatedEntranceId: 0
+  hasAssociatedEntrance: 1
+  associatedEntranceId: 3
   hasAssociatedExit: 1
   associatedExitId: 3
 --- !u!1001 &1731696211


### PR DESCRIPTION
Transitions 3 and 4 weren't associated to any entrances, so their blockers were present when entering form those transitions.