### PR TITLE
Collision sound corrections

### DIFF
--- a/Danki2/Assets/Prefabs/CollisionTemplates/Cylinder.prefab
+++ b/Danki2/Assets/Prefabs/CollisionTemplates/Cylinder.prefab
@@ -9,10 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7787781572118866137}
-  - component: {fileID: 6720954355662355197}
-  - component: {fileID: -5602313392232054037}
   - component: {fileID: -1595366432159826241}
-  - component: {fileID: 4030380208437600194}
   m_Layer: 12
   m_Name: Cylinder
   m_TagString: Untagged
@@ -30,32 +27,11 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 177844220082080486}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &6720954355662355197
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5381085625571238226}
-  m_Mesh: {fileID: 2534964839176971238, guid: acb4f86e2797b1a43b1f6eb96a8d3dc8, type: 3}
---- !u!64 &-5602313392232054037
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5381085625571238226}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 4
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 2534964839176971238, guid: acb4f86e2797b1a43b1f6eb96a8d3dc8, type: 3}
 --- !u!114 &-1595366432159826241
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -68,14 +44,69 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fb4b69da79670b14486bc51d0a09bf41, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  meshCollider: {fileID: -5602313392232054037}
---- !u!54 &4030380208437600194
+  meshCollider: {fileID: 526398229895761794}
+--- !u!1 &6525851013130335984
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 177844220082080486}
+  - component: {fileID: 9191076334379668376}
+  - component: {fileID: 526398229895761794}
+  - component: {fileID: 5368112459039660393}
+  m_Layer: 12
+  m_Name: Mesh
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &177844220082080486
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6525851013130335984}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 0.5, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7787781572118866137}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &9191076334379668376
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6525851013130335984}
+  m_Mesh: {fileID: 2534964839176971238, guid: acb4f86e2797b1a43b1f6eb96a8d3dc8, type: 3}
+--- !u!64 &526398229895761794
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6525851013130335984}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 2534964839176971238, guid: acb4f86e2797b1a43b1f6eb96a8d3dc8, type: 3}
+--- !u!54 &5368112459039660393
 Rigidbody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5381085625571238226}
+  m_GameObject: {fileID: 6525851013130335984}
   serializedVersion: 2
   m_Mass: 1
   m_Drag: 0

--- a/Danki2/Assets/Scenes/GameplayScenes/AbilityScene/AbilityScene.unity
+++ b/Danki2/Assets/Scenes/GameplayScenes/AbilityScene/AbilityScene.unity
@@ -11927,6 +11927,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Rock_Small7 (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4916821130090672697, guid: 9bc42ed9534222048b8baecf63c4557f,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9bc42ed9534222048b8baecf63c4557f, type: 3}
 --- !u!1001 &790049720
@@ -26122,6 +26127,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Rock_Small8 (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4916821130090672697, guid: b5bb12901fcdf4c4db61b45c508f47df,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b5bb12901fcdf4c4db61b45c508f47df, type: 3}
 --- !u!4 &1806962437 stripped
@@ -28207,6 +28217,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Pillar2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8571331540424614380, guid: 114245e04ec8d694ca01fdf12398e14a,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 114245e04ec8d694ca01fdf12398e14a, type: 3}

--- a/Danki2/Assets/Scenes/GameplayScenes/ForestValleyScene/ForestValleyScene.unity
+++ b/Danki2/Assets/Scenes/GameplayScenes/ForestValleyScene/ForestValleyScene.unity
@@ -10100,6 +10100,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: FencePost (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 7435412351846663316, guid: d1731357cd0a8b94db846f55dcc1357e,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d1731357cd0a8b94db846f55dcc1357e, type: 3}
 --- !u!1001 &1372060372
@@ -12891,6 +12896,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 84.414
+      objectReference: {fileID: 0}
+    - target: {fileID: 8143445739314373821, guid: a77d705311c7ff749913631a41fbd746,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a77d705311c7ff749913631a41fbd746, type: 3}
@@ -16420,6 +16430,11 @@ PrefabInstance:
     - target: {fileID: 2438809484675990865, guid: fbd132439cae90e4cb7a1f2cce06d827,
         type: 3}
       propertyPath: m_StaticEditorFlags
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5088949228653705873, guid: fbd132439cae90e4cb7a1f2cce06d827,
+        type: 3}
+      propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5871776065715656636, guid: fbd132439cae90e4cb7a1f2cce06d827,

--- a/Danki2/Assets/Scripts/Abilities/Ability.cs
+++ b/Danki2/Assets/Scripts/Abilities/Ability.cs
@@ -12,6 +12,8 @@ public abstract class Ability
     public const float MaxMeleeVerticalAngle = 30f;
     public const float MinMeleeVerticalAngle = -30f;
 
+    private const float DefaultCollisionTemplateHeight = 2f;
+
     private readonly string fmodVocalisationEvent;
     private readonly string fmodStartEvent;
     private readonly string fmodEndEvent;
@@ -78,7 +80,7 @@ public abstract class Ability
 
     protected void TemplateCollision(CollisionTemplateShape shape, float scale, Vector3 position, Quaternion rotation, Action<Actor> offensiveAction, CollisionSoundLevel? soundLevel = null)
     {
-        TemplateCollision(shape, scale * Vector3.one, position, rotation, offensiveAction, soundLevel);
+        TemplateCollision(shape, new Vector3(scale, DefaultCollisionTemplateHeight, scale), position, rotation, offensiveAction, soundLevel);
     }
 
     protected void TemplateCollision(CollisionTemplateShape shape, Vector3 scale, Vector3 position, Quaternion rotation, Action<Actor> offensiveAction, CollisionSoundLevel? soundLevel = null)

--- a/Danki2/Assets/Scripts/CollisionDetection/CollisionTemplate.cs
+++ b/Danki2/Assets/Scripts/CollisionDetection/CollisionTemplate.cs
@@ -68,15 +68,16 @@ public class CollisionTemplate : MonoBehaviour
     }
 
     private CollisionTemplate Initialise(Actor owner, Vector3 scale)
-    {
+    {        
         this.owner = owner;
 
-        Vector3 currentScale = meshCollider.transform.localScale;
-        if (currentScale != scale)
-        {
-            meshCollider.transform.localScale = scale;
-            ResetMesh(meshCollider);
-        }
+        Vector3 localScale = meshCollider.transform.localScale;
+        localScale.x *= scale.x;
+        localScale.y *= scale.y;
+        localScale.z *= scale.z;
+        meshCollider.transform.localScale = localScale;
+
+        ResetMesh(meshCollider);
 
         return this;
     }

--- a/Danki2/Assets/Scripts/CollisionDetection/CollisionTemplate.cs
+++ b/Danki2/Assets/Scripts/CollisionDetection/CollisionTemplate.cs
@@ -68,7 +68,7 @@ public class CollisionTemplate : MonoBehaviour
     }
 
     private CollisionTemplate Initialise(Actor owner, Vector3 scale)
-    {        
+    {
         this.owner = owner;
 
         Vector3 localScale = meshCollider.transform.localScale;


### PR DESCRIPTION
There's a few changes here:

1.  Changes to Collision Template script:
- The scale factor method of creating a template now uses a default height value of 2 and only scales x and z. This prevents high scale factors from hitting objects way above the player (i.e. lampposts) and low scale factors missing slightly raised objects (i.e. wraith).
- The method for scaling the prefab has been changed from setting the local scale to the scale vector, to multiplying the individual elements by the scale vectors corresponding elements. This is done because the cylinder must be scaled back to 1, 0.5, 1. The old method of setting the local scale caused the cylinder to be 4 units high rather than 2 units high; multiplying avoids this and is future proofed for any new templates which are also not 1, 1, 1 in shape.

2. Cylinder template prefab:
- The mesh is now a child of the prefab so that it may be scaled to 1, 0.5, 1 allowing it to appear at the expected scale whilst having a parent object scaled to 1, 1, 1.

3. Scene changes:
- The scenes have a number of objects which are low, these have colliders on them which cause a collision sound when an ability is cast 'above' them. The scenes have been reviewed and where low objects are present the collider has been deactivated, preventing unexpected collision sounds. This includes: fence posts in the forest valley scene and a collapsed ruin pillar and 2 small rocks in the ability scene.