### PR TITLE
Fix foliage shader depth write

### DIFF
--- a/Danki2/Assets/Materials/Environment/Natural/Plants/Grass.mat
+++ b/Danki2/Assets/Materials/Environment/Natural/Plants/Grass.mat
@@ -261,7 +261,7 @@ Material:
     - _TransparentDepthPrepassEnable: 0
     - _TransparentSortPriority: 0
     - _TransparentWritingMotionVec: 0
-    - _TransparentZWrite: 0
+    - _TransparentZWrite: 1
     - _UVBase: 0
     - _UVDetail: 0
     - _UVEmissive: 0
@@ -271,7 +271,7 @@ Material:
     - _ZTestGBuffer: 3
     - _ZTestModeDistortion: 4
     - _ZTestTransparent: 4
-    - _ZWrite: 0
+    - _ZWrite: 1
     m_Colors:
     - _BaseColor: {r: 0.49174294, g: 0.6226415, b: 0.48460305, a: 1}
     - _BaseColorMap_MipInfo: {r: 0, g: 0, b: 0, a: 0}

--- a/Danki2/Assets/Materials/Environment/Natural/Plants/Leaves.mat
+++ b/Danki2/Assets/Materials/Environment/Natural/Plants/Leaves.mat
@@ -242,7 +242,7 @@ Material:
     - _TransparentDepthPrepassEnable: 0
     - _TransparentSortPriority: 0
     - _TransparentWritingMotionVec: 0
-    - _TransparentZWrite: 0
+    - _TransparentZWrite: 1
     - _UVBase: 0
     - _UVDetail: 0
     - _UVEmissive: 0
@@ -252,7 +252,7 @@ Material:
     - _ZTestGBuffer: 3
     - _ZTestModeDistortion: 4
     - _ZTestTransparent: 4
-    - _ZWrite: 0
+    - _ZWrite: 1
     m_Colors:
     - _BaseColor: {r: 0.154122, g: 0.3584906, b: 0.13020648, a: 1}
     - _BaseColorMap_MipInfo: {r: 0, g: 0, b: 0, a: 0}

--- a/Danki2/Assets/Materials/Environment/Natural/Plants/Shrubs.mat
+++ b/Danki2/Assets/Materials/Environment/Natural/Plants/Shrubs.mat
@@ -261,10 +261,10 @@ Material:
     - _UVEmissive: 0
     - _UseEmissiveIntensity: 0
     - _UseShadowThreshold: 0
-    - _ZTestDepthEqualForOpaque: 2
+    - _ZTestDepthEqualForOpaque: 4
     - _ZTestGBuffer: 3
     - _ZTestModeDistortion: 4
-    - _ZTestTransparent: 2
+    - _ZTestTransparent: 4
     - _ZWrite: 1
     m_Colors:
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}

--- a/Danki2/Assets/Materials/Environment/Natural/Plants/Shrubs.mat
+++ b/Danki2/Assets/Materials/Environment/Natural/Plants/Shrubs.mat
@@ -255,17 +255,17 @@ Material:
     - _TransparentDepthPrepassEnable: 0
     - _TransparentSortPriority: 0
     - _TransparentWritingMotionVec: 0
-    - _TransparentZWrite: 0
+    - _TransparentZWrite: 1
     - _UVBase: 0
     - _UVDetail: 0
     - _UVEmissive: 0
     - _UseEmissiveIntensity: 0
     - _UseShadowThreshold: 0
-    - _ZTestDepthEqualForOpaque: 4
+    - _ZTestDepthEqualForOpaque: 2
     - _ZTestGBuffer: 3
     - _ZTestModeDistortion: 4
-    - _ZTestTransparent: 4
-    - _ZWrite: 0
+    - _ZTestTransparent: 2
+    - _ZWrite: 1
     m_Colors:
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _BaseColorMap_MipInfo: {r: 0, g: 0, b: 0, a: 0}


### PR DESCRIPTION
Foliage was drawing incorrectly when behind or in front of other transparent object, including other foliage. This was because it their shaders were set to not write to the Depth Buffer. This changes them to instead write to the Depth Buffer.