### PR TITLE
Fix whirlwind

### DIFF
--- a/Danki2/Assets/Prefabs/CollisionTemplates/Cylinder.prefab
+++ b/Danki2/Assets/Prefabs/CollisionTemplates/Cylinder.prefab
@@ -10,6 +10,9 @@ GameObject:
   m_Component:
   - component: {fileID: 7787781572118866137}
   - component: {fileID: -1595366432159826241}
+  - component: {fileID: 7297189665590438933}
+  - component: {fileID: 8997751931170959432}
+  - component: {fileID: 6462415207331457158}
   m_Layer: 12
   m_Name: Cylinder
   m_TagString: Untagged
@@ -26,9 +29,8 @@ Transform:
   m_GameObject: {fileID: 5381085625571238226}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 177844220082080486}
+  m_LocalScale: {x: 1, y: 0.5, z: 1}
+  m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -44,55 +46,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fb4b69da79670b14486bc51d0a09bf41, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  meshCollider: {fileID: 526398229895761794}
---- !u!1 &6525851013130335984
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 177844220082080486}
-  - component: {fileID: 9191076334379668376}
-  - component: {fileID: 526398229895761794}
-  - component: {fileID: 5368112459039660393}
-  m_Layer: 12
-  m_Name: Mesh
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &177844220082080486
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6525851013130335984}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 0.5, z: 1}
-  m_Children: []
-  m_Father: {fileID: 7787781572118866137}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &9191076334379668376
+  meshCollider: {fileID: 8997751931170959432}
+--- !u!33 &7297189665590438933
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6525851013130335984}
+  m_GameObject: {fileID: 5381085625571238226}
   m_Mesh: {fileID: 2534964839176971238, guid: acb4f86e2797b1a43b1f6eb96a8d3dc8, type: 3}
---- !u!64 &526398229895761794
+--- !u!64 &8997751931170959432
 MeshCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6525851013130335984}
+  m_GameObject: {fileID: 5381085625571238226}
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
@@ -100,13 +69,13 @@ MeshCollider:
   m_Convex: 1
   m_CookingOptions: 30
   m_Mesh: {fileID: 2534964839176971238, guid: acb4f86e2797b1a43b1f6eb96a8d3dc8, type: 3}
---- !u!54 &5368112459039660393
+--- !u!54 &6462415207331457158
 Rigidbody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6525851013130335984}
+  m_GameObject: {fileID: 5381085625571238226}
   serializedVersion: 2
   m_Mass: 1
   m_Drag: 0

--- a/Danki2/Assets/Scripts/Abilities/Channel/Channel/Whirlwind.cs
+++ b/Danki2/Assets/Scripts/Abilities/Channel/Channel/Whirlwind.cs
@@ -57,7 +57,7 @@ public class Whirlwind : Channel
         TemplateCollision(
             CollisionTemplateShape.Cylinder,
             radius,
-            Owner.transform.position,
+            Owner.CollisionTemplateSource,
             Quaternion.identity,
             actor =>
             {


### PR DESCRIPTION
- Move cylinder components to top level of prefab. This is fine because we multiply the template's scale rather than set it.
- Moves whirlwind template to be spawned at the collision template source so that it doesn't collide with everything on the floor.