### PR TITLE
Cheese proof wolf

### DIFF
--- a/Danki2/Assets/Prefabs/Enemies/Wolf.prefab
+++ b/Danki2/Assets/Prefabs/Enemies/Wolf.prefab
@@ -626,10 +626,10 @@ MonoBehaviour:
   biteMaxAngle: 3
   biteDelay: 0.5
   biteCooldown: 2.5
-  pounceMinRange: 4
-  pounceMaxRange: 10
+  pounceMinRange: 3
+  pounceMaxRange: 12
   pounceDelay: 0.5
-  pounceCooldown: 5
+  pounceCooldown: 4
   minCircleDistance: 2
   maxCircleDistance: 9
 --- !u!195 &-7685572653157387656

--- a/Danki2/Assets/Prefabs/Enemies/Wolf.prefab
+++ b/Danki2/Assets/Prefabs/Enemies/Wolf.prefab
@@ -621,6 +621,7 @@ MonoBehaviour:
   minEvadeTime: 4
   maxEvadeTime: 8
   followDistance: 2.5
+  biteRotationSmoothingOverride: 0.03
   biteRange: 3
   biteMaxAngle: 3
   biteDelay: 0.5

--- a/Danki2/Assets/Scripts/AI/AIs/WolfAi.cs
+++ b/Danki2/Assets/Scripts/AI/AIs/WolfAi.cs
@@ -51,9 +51,8 @@ public class WolfAi : Ai
             .WithTransition(PatrolState.RandomMovement, PatrolState.StandStill, new RandomTimeElapsed(minMovementTime, maxMovementTime));
 
         IStateMachineComponent attackStateMachine = new StateMachine<AttackState>(AttackState.InitialReposition)
-            .WithComponent(AttackState.InitialReposition, new MoveTowardsAtDistance(wolf, player, followDistance))
-            .WithComponent(AttackState.Reposition, new MoveTowardsAtDistance(wolf, player, followDistance))
-            .WithComponent(AttackState.WatchTarget, new WatchTarget(wolf, player, biteRotationSmoothingOverride))
+            .WithComponent(AttackState.InitialReposition, new MoveTowardsAtDistance(wolf, player, followDistance, biteRotationSmoothingOverride))
+            .WithComponent(AttackState.Reposition, new MoveTowardsAtDistance(wolf, player, followDistance, biteRotationSmoothingOverride))
             .WithComponent(AttackState.TelegraphBite, new TelegraphAttack(wolf, Color.red))
             .WithComponent(AttackState.Bite, new WolfBite(wolf))
             .WithComponent(AttackState.TelegraphPounce, new TelegraphAttack(wolf, Color.green))
@@ -72,21 +71,6 @@ public class WolfAi : Ai
                 AttackState.Reposition,
                 AttackState.TelegraphBite,
                 new DistanceLessThan(wolf, player, biteRange) & new TimeElapsed(biteCooldown) & new Facing(wolf, player, biteMaxAngle)
-            )
-            .WithTransition(
-                AttackState.Reposition,
-                AttackState.WatchTarget,
-                new DistanceLessThan(wolf, player, followDistance) & new TimeElapsed(biteCooldown)
-            )
-            .WithTransition(
-                AttackState.WatchTarget,
-                AttackState.Reposition,
-                new DistanceGreaterThan(wolf, player, followDistance)
-            )
-            .WithTransition(
-                AttackState.WatchTarget,
-                AttackState.TelegraphBite,
-                new DistanceLessThan(wolf, player, biteRange) & new Facing(wolf, player, biteMaxAngle)
             )
             .WithTransition(AttackState.TelegraphBite, AttackState.Reposition, new Interrupted(wolf, InterruptionType.Hard))
             .WithTransition(AttackState.TelegraphBite, AttackState.Bite, new TimeElapsed(biteDelay))
@@ -147,7 +131,6 @@ public class WolfAi : Ai
     {
         InitialReposition,
         Reposition,
-        WatchTarget,
         TelegraphBite,
         Bite,
         TelegraphPounce,


### PR DESCRIPTION
To do:

- Increase turn speed, maybe decrease bite telegraph time? Rather than turning towards you forever, the turn speed could slowly increase, or the wolf could pounce away if turning for too long. **Completed by creating a new AttackState for close range where the wolf has an increased rotation speed, resulting in Bite being cast when the player tightly circles, followed by a retreating dash.**

- Pounce more often when you are running away. **Completed by buffing Pounce cast distances to make it more likely to occur and also reducing the cooldown to 4 from 5. The wolf now seems to utilise Pounce more when the Player keeps a distance than before.**

- Test out and try and cheese it in other ways. **Couldn't find anything else in particular, take a look to check?**