### PR TITLE
Remove some abilities

### DIFF
--- a/Danki2/Assets/Prefabs/Meta/GameplayManagers/AbilityLookup.prefab
+++ b/Danki2/Assets/Prefabs/Meta/GameplayManagers/AbilityLookup.prefab
@@ -229,7 +229,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       rarity: 0
-      playerCanCast: 1
+      playerCanCast: 0
       finisher: 0
       channelDuration: 0.5
     - displayName: Sweeping Strike
@@ -248,7 +248,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       rarity: 1
-      playerCanCast: 1
+      playerCanCast: 0
       finisher: 0
       channelDuration: 0
     - displayName: Grappling Hook

--- a/Danki2/Assets/Prefabs/Meta/GameplayManagers/AbilityLookup.prefab
+++ b/Danki2/Assets/Prefabs/Meta/GameplayManagers/AbilityLookup.prefab
@@ -134,7 +134,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       rarity: 1
-      playerCanCast: 1
+      playerCanCast: 0
       finisher: 0
       channelDuration: 0
     - displayName: Bite
@@ -393,7 +393,7 @@ MonoBehaviour:
           tooltip: Throw an additional 2 knives.
           requiredTreeDepth: 4
       rarity: 0
-      playerCanCast: 1
+      playerCanCast: 0
       finisher: 0
       channelDuration: 0
     - displayName: Hamstring
@@ -514,7 +514,7 @@ MonoBehaviour:
           tooltip: The knives are barbed, causing {BLEED|1}.
           requiredTreeDepth: 3
       rarity: 2
-      playerCanCast: 1
+      playerCanCast: 0
       finisher: 1
       channelDuration: 0
     - displayName: Execute

--- a/Danki2/Assets/Prefabs/Meta/GameplayManagers/AbilityLookup.prefab
+++ b/Danki2/Assets/Prefabs/Meta/GameplayManagers/AbilityLookup.prefab
@@ -334,7 +334,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       rarity: 2
-      playerCanCast: 1
+      playerCanCast: 0
       finisher: 0
       channelDuration: 1
     - displayName: Rend
@@ -560,7 +560,7 @@ MonoBehaviour:
         _keys: []
         _values: []
       rarity: 1
-      playerCanCast: 1
+      playerCanCast: 0
       finisher: 0
       channelDuration: 2
     - displayName: Poison Stab

--- a/Danki2/Assets/Prefabs/Meta/MapGenerationLookup.prefab
+++ b/Danki2/Assets/Prefabs/Meta/MapGenerationLookup.prefab
@@ -46,7 +46,7 @@ MonoBehaviour:
   abilityChoices: 3
   runeSockets: 3
   leftStartingAbility: 0
-  rightStartingAbility: 7
+  rightStartingAbility: 5
   generatedRoomDepth: 2
   minRoomExits: 1
   maxRoomExits: 3


### PR DESCRIPTION
Left in lunge and smash even though they have a stun since they work even if the stun was disabled. Disabled bash as it becomes a redundant ability if the stun part is removed.

Disabled all other abilities per card.