### PR TITLE
Sets editor as dirty when dev managers are toggled

### DIFF
--- a/Danki2/Assets/Scripts/Editor/DankiMenu.cs
+++ b/Danki2/Assets/Scripts/Editor/DankiMenu.cs
@@ -43,5 +43,7 @@ public static class DankiMenu
         devManagerObject.SetActive(!devManagerObject.activeInHierarchy);
 
         Selection.activeGameObject = devManagerObject;
+        
+        EditorUtility.SetDirty(devManagerObject);
     }
 }


### PR DESCRIPTION
This means that the changes to the object will be picked up by the editor when the toggle button is clicked