### PR TITLE
Day night ambience parameter

### DIFF
--- a/Danki2/Assets/Prefabs/Meta/GameplayManagers/AmbientSoundManager.prefab
+++ b/Danki2/Assets/Prefabs/Meta/GameplayManagers/AmbientSoundManager.prefab
@@ -68,3 +68,36 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   eventEmitter: {fileID: 7126066241767367734}
+  dayNightCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: -0.5
+      inSlope: 2
+      outSlope: 2
+      tangentMode: 34
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.5
+      value: 0.5
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 34
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: -0.5
+      inSlope: -2
+      outSlope: -2
+      tangentMode: 34
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Danki2/Assets/Prefabs/Meta/GameplayManagers/AmbientSoundManager.prefab
+++ b/Danki2/Assets/Prefabs/Meta/GameplayManagers/AmbientSoundManager.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7126066241767367733}
   - component: {fileID: 7126066241767367734}
+  - component: {fileID: 4939277318790775535}
   m_Layer: 0
   m_Name: AmbientSoundManager
   m_TagString: Untagged
@@ -54,3 +55,16 @@ MonoBehaviour:
   OverrideAttenuation: 0
   OverrideMinDistance: 0
   OverrideMaxDistance: 0
+--- !u!114 &4939277318790775535
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7126066241767367732}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3aabb4cac7d93654695cfa040a275c79, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  eventEmitter: {fileID: 7126066241767367734}

--- a/Danki2/Assets/Scripts/Audio/AmbientSoundManager.cs
+++ b/Danki2/Assets/Scripts/Audio/AmbientSoundManager.cs
@@ -10,11 +10,15 @@ public class AmbientSoundManager : Singleton<AmbientSoundManager>
         [AmbientSoundType.Night] = 0,
     };
 
-    [SerializeField]
-    private StudioEventEmitter eventEmitter = null;
+    [SerializeField] private StudioEventEmitter eventEmitter = null;
+    [SerializeField] private AnimationCurve dayNightCurve = null;
 
     private void Start()
     {
-        eventEmitter.SetParameter("dayNight", parameterLookup[AmbientSoundType.Day]);
+        float depthProportion = DepthUtils.GetDepthProportion(PersistenceManager.Instance.SaveData.CurrentRoomNode);
+        float dayNightCurveValue = dayNightCurve.Evaluate(depthProportion);
+        AmbientSoundType ambientSoundType = dayNightCurveValue > 0 ? AmbientSoundType.Day : AmbientSoundType.Night;
+
+        eventEmitter.SetParameter("dayNight", parameterLookup[ambientSoundType]);
     }
 }

--- a/Danki2/Assets/Scripts/Audio/AmbientSoundManager.cs
+++ b/Danki2/Assets/Scripts/Audio/AmbientSoundManager.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using FMODUnity;
+using UnityEngine;
+
+public class AmbientSoundManager : Singleton<AmbientSoundManager>
+{
+    private static readonly Dictionary<AmbientSoundType, float> parameterLookup = new Dictionary<AmbientSoundType, float>
+    {
+        [AmbientSoundType.Day] = 1,
+        [AmbientSoundType.Night] = 0,
+    };
+
+    [SerializeField]
+    private StudioEventEmitter eventEmitter = null;
+
+    private void Start()
+    {
+        eventEmitter.SetParameter("dayNight", parameterLookup[AmbientSoundType.Day]);
+    }
+}

--- a/Danki2/Assets/Scripts/Audio/AmbientSoundManager.cs.meta
+++ b/Danki2/Assets/Scripts/Audio/AmbientSoundManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3aabb4cac7d93654695cfa040a275c79
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Danki2/Assets/Scripts/Audio/AmbientSoundType.cs
+++ b/Danki2/Assets/Scripts/Audio/AmbientSoundType.cs
@@ -1,0 +1,5 @@
+public enum AmbientSoundType
+{
+    Day,
+    Night
+}

--- a/Danki2/Assets/Scripts/Audio/AmbientSoundType.cs.meta
+++ b/Danki2/Assets/Scripts/Audio/AmbientSoundType.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0e4ecc92af0848b8b64f969f265f11ed
+timeCreated: 1626693100

--- a/Danki2/Assets/Scripts/Lighting/DynamicLighting.cs
+++ b/Danki2/Assets/Scripts/Lighting/DynamicLighting.cs
@@ -31,10 +31,7 @@ public class DynamicLighting : Singleton<DynamicLighting>
         RoomNode currentRoomNode = PersistenceManager.Instance.SaveData.CurrentRoomNode;
 
         InitialiseLights(
-            GetDepthProportion(
-                currentRoomNode.DepthInZone,
-                MapGenerationLookup.Instance.RoomsPerZoneLookup[currentRoomNode.Zone]
-            ),
+            DepthUtils.GetDepthProportion(currentRoomNode),
             currentRoomNode.CameraOrientation
         );
     }
@@ -57,10 +54,5 @@ public class DynamicLighting : Singleton<DynamicLighting>
             data.YAngle.Evaluate(depthProportion) + yRotation,
             0
         );
-    }
-
-    private float GetDepthProportion(int currentDepth, int maxDepth)
-    {
-        return (float) (currentDepth - 1) / (maxDepth - 1);
     }
 }

--- a/Danki2/Assets/Scripts/Utils/DepthUtils.cs
+++ b/Danki2/Assets/Scripts/Utils/DepthUtils.cs
@@ -1,0 +1,10 @@
+public static class DepthUtils
+{
+    public static float GetDepthProportion(RoomNode currentRoomNode)
+    {
+        int currentDepth = currentRoomNode.DepthInZone;
+        int maxDepth = MapGenerationLookup.Instance.RoomsPerZoneLookup[currentRoomNode.Zone];
+
+        return (float) (currentDepth - 1) / (maxDepth - 1);
+    }
+}

--- a/Danki2/Assets/Scripts/Utils/DepthUtils.cs.meta
+++ b/Danki2/Assets/Scripts/Utils/DepthUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6889c481e7dcda48b977e978c638ab3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Blocked by `fix-vocalisation-levels` branch, just because that makes a new folder called "Audio" that this branch uses too.

Thought about plugging this into the dynamic lighting to try to work out if it's day or night, but I think that leads to unnecessary coupling. It seems nicer to just be able to manage this through a totally separate animation curve and this will give us more freedom long-term.