### PR TITLE
add event driven footsteps for the player

### DIFF
--- a/Danki2/Assets/Animations/Actor/Player/Player_actor_skinned_mesh_animations.fbx.meta
+++ b/Danki2/Assets/Animations/Actor/Player/Player_actor_skinned_mesh_animations.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 292b04f93f5a3b8448bc1e46edeb131e
 ModelImporter:
-  serializedVersion: 19301
+  serializedVersion: 20200
   internalIDToNameTable:
   - first:
       74: 5268829706552777367
@@ -42,35 +42,7 @@ ModelImporter:
     rigImportErrors: 
     rigImportWarnings: 
     animationImportErrors: 
-    animationImportWarnings: "\nClip 'PlayerArmature|ArmatureAction' has import animation
-      warnings that might lower retargeting quality:\nNote: Activate translation
-      DOF on avatar to improve retargeting quality.\n\t'CoreIK' has translation animation
-      that will be discarded.\n\t'Spine.003' has translation animation that will
-      be discarded.\n\t'Forearm.L' is inbetween humanoid transforms and has rotation
-      animation that will be discarded.\n\t'Pinky.001.L' has translation animation
-      that will be discarded.\n\t'Ring.001.L' has translation animation that will
-      be discarded.\n\t'Middle.001.L' has translation animation that will be discarded.\n\t'Index.001.L'
-      has translation animation that will be discarded.\n\t'Forearm.R' is inbetween
-      humanoid transforms and has rotation animation that will be discarded.\n\t'Pinky.001.R'
-      has translation animation that will be discarded.\n\t'Ring.001.R' has translation
-      animation that will be discarded.\n\t'Middle.001.R' has translation animation
-      that will be discarded.\n\t'Index.001.R' has translation animation that will
-      be discarded.\n\t'Shin.L' is inbetween humanoid transforms and has rotation
-      animation that will be discarded.\n\t'Shin.R' is inbetween humanoid transforms
-      and has rotation animation that will be discarded.\n\nClip 'PlayerArmature|Character_Library'
-      has import animation warnings that might lower retargeting quality:\nNote:
-      Activate translation DOF on avatar to improve retargeting quality.\n\t'Forearm.L'
-      is inbetween humanoid transforms and has rotation animation that will be discarded.\n\t'Pinky.001.L'
-      has translation animation that will be discarded.\n\t'Ring.001.L' has translation
-      animation that will be discarded.\n\t'Middle.001.L' has translation animation
-      that will be discarded.\n\t'Index.001.L' has translation animation that will
-      be discarded.\n\t'Forearm.R' is inbetween humanoid transforms and has rotation
-      animation that will be discarded.\n\t'Pinky.001.R' has translation animation
-      that will be discarded.\n\t'Ring.001.R' has translation animation that will
-      be discarded.\n\t'Middle.001.R' has translation animation that will be discarded.\n\t'Index.001.R'
-      has translation animation that will be discarded.\n\t'Shin.L' is inbetween
-      humanoid transforms and has rotation animation that will be discarded.\n\t'Shin.R'
-      is inbetween humanoid transforms and has rotation animation that will be discarded.\n"
+    animationImportWarnings: 
     animationRetargetingWarnings: 
     animationDoRetargetingWarnings: 0
     importAnimatedCustomProperties: 0
@@ -165,7 +137,21 @@ ModelImporter:
       mirror: 0
       bodyMask: 01000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000
       curves: []
-      events: []
+      events:
+      - time: 0.4287294
+        functionName: Step
+        data: 
+        objectReferenceParameter: {instanceID: 0}
+        floatParameter: 0
+        intParameter: 0
+        messageOptions: 0
+      - time: 0.9312257
+        functionName: Step
+        data: 
+        objectReferenceParameter: {instanceID: 0}
+        floatParameter: 0
+        intParameter: 0
+        messageOptions: 0
       transformMask: []
       maskType: 3
       maskSource: {instanceID: 0}
@@ -304,6 +290,7 @@ ModelImporter:
     useFileUnits: 1
     keepQuads: 0
     weldVertices: 1
+    bakeAxisConversion: 0
     preserveHierarchy: 0
     skinWeightsMode: 0
     maxBonesPerVertex: 4
@@ -313,6 +300,9 @@ ModelImporter:
     secondaryUVAngleDistortion: 8
     secondaryUVAreaDistortion: 15.000001
     secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
     secondaryUVPackMargin: 4
     useFileScale: 1
   tangentSpace:
@@ -799,6 +789,7 @@ ModelImporter:
   animationType: 2
   humanoidOversampling: 1
   avatarSetup: 1
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 0
   additionalBone: 0
   userData: 
   assetBundleName: 

--- a/Danki2/Assets/Prefabs/Player/Player.prefab
+++ b/Danki2/Assets/Prefabs/Player/Player.prefab
@@ -3603,6 +3603,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6174604534595793060}
   - component: {fileID: 238891752984210142}
+  - component: {fileID: 2170988536928494298}
   m_Layer: 14
   m_Name: Player_actor_skinned_mesh
   m_TagString: Untagged
@@ -3650,6 +3651,20 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!114 &2170988536928494298
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6844146180703218206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 153257a404946c247836dc085176ced0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  footstepEvent: event:/CS_CharacterSounds/CS_Footsteps
+  actor: {fileID: -5201030127241623248}
 --- !u!1 &6922829322607958891
 GameObject:
   m_ObjectHideFlags: 0

--- a/Danki2/Assets/Scripts/Actor/Components/Footsteps.cs
+++ b/Danki2/Assets/Scripts/Actor/Components/Footsteps.cs
@@ -4,8 +4,7 @@ using UnityEngine;
 
 public class Footsteps : MonoBehaviour
 {
-    [SerializeField]
-    [EventRef]
+    [SerializeField, EventRef]
     private string footstepEvent = null;
 
     [SerializeField]

--- a/Danki2/Assets/Scripts/Actor/Components/Footsteps.cs
+++ b/Danki2/Assets/Scripts/Actor/Components/Footsteps.cs
@@ -1,0 +1,25 @@
+﻿using FMOD.Studio;
+using FMODUnity;
+using UnityEngine;
+
+public class Footsteps : MonoBehaviour
+{
+    [SerializeField]
+    [EventRef]
+    private string footstepEvent = null;
+
+    [SerializeField]
+    private Actor actor;
+
+    // We don't want to hear footsteps when highly blended with other animations
+    private const float MinWeightThreshold = 0.5f;
+
+    public void Step(AnimationEvent animationEvent)
+    {
+        if (animationEvent.animatorClipInfo.weight < MinWeightThreshold) return;
+
+        EventInstance instance = FmodUtils.CreatePositionedInstance(footstepEvent, actor.transform.position);
+        instance.start();
+        instance.release();
+    }
+}

--- a/Danki2/Assets/Scripts/Actor/Components/Footsteps.cs.meta
+++ b/Danki2/Assets/Scripts/Actor/Components/Footsteps.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 153257a404946c247836dc085176ced0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The player has a blended run/idle animation based on run speed. Therefore to stop the footstep sound playing when idle, we need to discard Step events that have a low weight - hence the MinWeightThreshold const on the footsteps component.

Animation events call any methods on components in the same gameobject as the animator based on a string 'Function' name. This is why the footsteps component is placed on the gameobject which holds the animator. It might be worth doing something to signal when a component is designed to sit with animator and listen to animation events.