### PR TITLE
fix the rune tooltip

### DIFF
--- a/Danki2/Assets/Scripts/UI/Menus/Runes/ClickableRunePanel.cs
+++ b/Danki2/Assets/Scripts/UI/Menus/Runes/ClickableRunePanel.cs
@@ -28,6 +28,6 @@ public class ClickableRunePanel : MonoBehaviour
 
     private void Initialise(RuneSocket runeSocket)
     {
-        runePanel.Initialise(runeSocket.HasRune ? runeSocket.Rune : (Rune?) null);
+        runePanel.Initialise(transform.parent, runeSocket.HasRune ? runeSocket.Rune : (Rune?) null);
     }
 }

--- a/Danki2/Assets/Scripts/UI/Menus/Runes/RunePanel.cs
+++ b/Danki2/Assets/Scripts/UI/Menus/Runes/RunePanel.cs
@@ -10,12 +10,13 @@ public class RunePanel : MonoBehaviour
     [SerializeField] private Text text = null;
 
     private Rune? rune;
+    private Transform containerTransform;
     private RuneTooltip runeTooltip;
     
     public static RunePanel Create(RunePanel prefab, Transform transform, Rune? rune = null)
     {
         RunePanel runePanel = Instantiate(prefab, transform);
-        runePanel.Initialise(rune);
+        runePanel.Initialise(transform, rune);
         return runePanel;
     }
 
@@ -23,14 +24,15 @@ public class RunePanel : MonoBehaviour
 
     public void PointerEnter()
     {
-        if (rune.HasValue) runeTooltip = RuneTooltip.Create(rune.Value, transform.parent);
+        if (rune.HasValue) runeTooltip = RuneTooltip.Create(rune.Value, containerTransform);
     }
 
     public void PointerExit() => TryDestroyTooltip();
     
-    public void Initialise(Rune? rune = null)
+    public void Initialise(Transform containerTransform, Rune? rune = null)
     {
         this.rune = rune;
+        this.containerTransform = containerTransform;
 
         if (this.rune.HasValue)
         {

--- a/Danki2/Assets/Scripts/UI/Menus/Runes/RuneSelectionMenu/RuneSelectionMenu.cs
+++ b/Danki2/Assets/Scripts/UI/Menus/Runes/RuneSelectionMenu/RuneSelectionMenu.cs
@@ -18,7 +18,7 @@ public class RuneSelectionMenu : MonoBehaviour
     private void Start()
     {
         nextRune = ActorCache.Instance.Player.RuneManager.GetNextRune();
-        nextRunePanel.Initialise(nextRune);
+        nextRunePanel.Initialise(transform, nextRune);
     }
 
     private void OnEnable()

--- a/Danki2/Assets/Scripts/UI/Menus/Tooltips/AbilityTooltip/AbilityTooltip.cs
+++ b/Danki2/Assets/Scripts/UI/Menus/Tooltips/AbilityTooltip/AbilityTooltip.cs
@@ -18,17 +18,17 @@ public class AbilityTooltip : Tooltip
 
     private readonly List<AbilityBonusTooltipSection> bonusSections = new List<AbilityBonusTooltipSection>();
     
-    public static AbilityTooltip Create(Transform transform, Ability ability)
+    public static AbilityTooltip Create(Transform menuTransform, Ability ability)
     {
-        AbilityTooltip abilityTooltip = Instantiate(TooltipLookup.Instance.AbilityTooltipPrefab, transform);
+        AbilityTooltip abilityTooltip = Instantiate(TooltipLookup.Instance.AbilityTooltipPrefab, menuTransform);
         abilityTooltip.Activate(ability);
 
         return abilityTooltip;
     }
 
-    public static AbilityTooltip Create(Transform transform, Node node)
+    public static AbilityTooltip Create(Transform menuTransform, Node node)
     {
-        AbilityTooltip abilityTooltip = Instantiate(TooltipLookup.Instance.AbilityTooltipPrefab, transform);
+        AbilityTooltip abilityTooltip = Instantiate(TooltipLookup.Instance.AbilityTooltipPrefab, menuTransform);
         abilityTooltip.Activate(node.Ability);
 
         return abilityTooltip;

--- a/Danki2/Assets/Scripts/UI/Menus/Tooltips/SupplementaryTooltipPanel.cs
+++ b/Danki2/Assets/Scripts/UI/Menus/Tooltips/SupplementaryTooltipPanel.cs
@@ -55,20 +55,20 @@ public class SupplementaryTooltipPanel : MonoBehaviour
     {
         Activate();
 
-        List<Tuple<string, string>> tuples = new List<Tuple<string, string>>();
-        empowerments?.Distinct().ToList().ForEach(e => tuples.Add(Tuple.Create(
+        List<(string, string)> tuples = new List<(string, string)>();
+        empowerments?.Distinct().ToList().ForEach(e => tuples.Add((
             EmpowermentLookup.Instance.GetDisplayName(e),
             EmpowermentLookup.Instance.GetTooltip(e)
         )));
-        activeEffects?.Distinct().ToList().ForEach(e => tuples.Add(Tuple.Create(
+        activeEffects?.Distinct().ToList().ForEach(e => tuples.Add((
             EffectLookup.Instance.GetDisplayName(e),
             EffectLookup.Instance.GetTooltip(e)
         )));
-        passiveEffects?.Distinct().ToList().ForEach(e => tuples.Add(Tuple.Create(
+        passiveEffects?.Distinct().ToList().ForEach(e => tuples.Add((
             EffectLookup.Instance.GetDisplayName(e),
             EffectLookup.Instance.GetTooltip(e)
         )));
-        stackingEffects?.Distinct().ToList().ForEach(e => tuples.Add(Tuple.Create(
+        stackingEffects?.Distinct().ToList().ForEach(e => tuples.Add((
             EffectLookup.Instance.GetDisplayName(e),
             EffectLookup.Instance.GetTooltip(e)
         )));
@@ -81,7 +81,7 @@ public class SupplementaryTooltipPanel : MonoBehaviour
         rectTransform.pivot = pivotPoints[currentScreenQuadrant];
     }
 
-    private void Display(List<Tuple<string, string>> tooltips)
+    private void Display(List<(string, string)> tooltips)
     {
         tooltips.ForEach(t =>
         {


### PR DESCRIPTION
Acceptance criteria:
- Rune tooltip always appears in front of runes in the rune menu AND the rune selection menu
- Tooltip works as expected closing rune menus while the tooltip is visible and re-opening