### PR TITLE
improve player spotlight

### DIFF
--- a/Danki2/Assets/Prefabs/Player/Player.prefab
+++ b/Danki2/Assets/Prefabs/Player/Player.prefab
@@ -44,7 +44,7 @@ Light:
   m_Type: 0
   m_Shape: 0
   m_Color: {r: 1, g: 0.87716293, b: 0.6273585, a: 1}
-  m_Intensity: 145.56868
+  m_Intensity: 198.94368
   m_Range: 17.08
   m_SpotAngle: 128
   m_InnerSpotAngle: 21.80208
@@ -85,14 +85,14 @@ Light:
   m_RenderingLayerMask: 1
   m_Lightmapping: 4
   m_LightShadowCasterMode: 2
-  m_AreaSize: {x: 1, y: 1}
+  m_AreaSize: {x: 0.5, y: 0.5}
   m_BounceIntensity: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
   m_UseBoundingSphereOverride: 0
   m_UseViewFrustumForShadowCasterCull: 1
-  m_ShadowRadius: 0
+  m_ShadowRadius: 2
   m_ShadowAngle: 0
 --- !u!114 &4680388
 MonoBehaviour:
@@ -114,7 +114,7 @@ MonoBehaviour:
   m_PointlightHDType: 0
   m_SpotLightShape: 0
   m_AreaLightShape: 0
-  m_Intensity: 1829.27
+  m_Intensity: 2500
   m_EnableSpotReflector: 0
   m_LuxAtDistance: 1
   m_InnerSpotPercent: 26.9
@@ -130,7 +130,7 @@ MonoBehaviour:
   m_ShapeWidth: 0.5
   m_ShapeHeight: 0.5
   m_AspectRatio: 1
-  m_ShapeRadius: 0
+  m_ShapeRadius: 2
   m_SoftnessScale: 1
   m_UseCustomSpotLightShadowCone: 0
   m_CustomSpotLightShadowCone: 30
@@ -166,7 +166,7 @@ MonoBehaviour:
   m_EvsmBlurPasses: 0
   m_LightlayersMask: 1
   m_LinkShadowLayers: 1
-  m_ShadowNearPlane: 0.1
+  m_ShadowNearPlane: 3.155
   m_BlockerSampleCount: 24
   m_FilterSampleCount: 16
   m_MinFilterSize: 0.01
@@ -2801,8 +2801,8 @@ SkinnedMeshRenderer:
   m_BlendShapeWeights: []
   m_RootBone: {fileID: 0}
   m_AABB:
-    m_Center: {x: 0.000016085804, y: 0.9069459, z: 0.3443155}
-    m_Extent: {x: 0.11475015, y: 0.32049662, z: 0.23015854}
+    m_Center: {x: 0.00003077835, y: 0.9071213, z: 0.3470184}
+    m_Extent: {x: 0.114761665, y: 0.32032123, z: 0.23286143}
   m_DirtyAABB: 0
 --- !u!183 &5250604633547756724
 Cloth:


### PR DESCRIPTION
Added radius and shadow near plane so that overhead objects interfere with the light a lot less.

To see the improvement, play the ruins scene in dev mode and try walking up and down the steps and under the tree at the bottom of the steps.